### PR TITLE
Change rfsettings offset to vfo

### DIFF
--- a/cutesdr-vk6hl.json
+++ b/cutesdr-vk6hl.json
@@ -19,7 +19,7 @@
             "config": {
               "lines": [9, 10, 11, 17],
               "defaultOut": 8,
-              "settingPath": "tx.rf.frequency",
+              "settingPath": "band.selected.tx-pipeline.rf.center-frequency.value",
               "bands": [
                 {
                   "fromFrequency": 1800000,
@@ -90,7 +90,7 @@
                           "lines": [8, 7],
                           "bias": "pull-up",
                           "debounce": true,
-                          "settingPath": "mode"
+                          "settingPath": "band.selected.rx-pipeline.mode"
                       }
                   },
                   {
@@ -100,7 +100,7 @@
                           "lines": [13, 12],
                           "bias": "pull-up",
                           "debounce": true,
-                          "settingPath": "tx.mic.gain"
+                          "settingPath": "band.select"
                       }
                   },
                   {
@@ -110,7 +110,7 @@
                           "lines": [26, 16],
                           "bias": "pull-up",
                           "debounce": true,
-                          "settingPath": "frequency"
+                          "settingPath": "band.selected.rx-pipeline.rf.center-frequency.value.coarse"
                       }
                   },
                   {
@@ -120,7 +120,7 @@
                           "lines": [15, 14],
                           "bias": "none",
                           "debounce": false,
-                          "settingPath": "offset"
+                          "settingPath": "band.selected.rx-pipeline.rf.vfo.value"
                       }
                   }
               ]
@@ -135,11 +135,11 @@
           "config": {
             "audioInput": {
 			  "soundApi": "alsa",
-			  "searchExpression": "HiFiBerry",
+			  "searchExpression": "FunCube",
 			  "sampleRate": 192000,
 			  "channelCount": 2
            },
-            "reverse": true
+            "reverse": false
           }
         },
         "audioOutput": {

--- a/dsp/pipeline/IqPipeline.cpp
+++ b/dsp/pipeline/IqPipeline.cpp
@@ -2,9 +2,11 @@
 // Created by murray on 18/11/25.
 //
 #include "IqPipeline.h"
+#include "settings/PipelineSettings.h"
 
 #define DEFAULT_PING_PONG_LENGTH 8192
 
+class RfSettings;
 class ModeSettings;
 
 IqPipeline::IqPipeline(QObject* eventTarget) :
@@ -16,4 +18,27 @@ IqPipeline::IqPipeline(QObject* eventTarget) :
   m_outputSampleRate(0),
   m_pAudioOutSink(nullptr)
 {
+}
+
+void
+IqPipeline::apply(const PipelineSettings* settings)
+{
+  if (settings != nullptr) {
+    std::lock_guard<std::mutex> lock(m_settingsMutex);
+    if (settings->hasSettingChanged(PipelineSettings::RF)) {
+      const RfSettings& rfSettings = settings->getRfSettings();
+      if (rfSettings.hasSettingChanged(RfSettings::CENTER_FREQUENCY)
+          || rfSettings.hasSettingChanged(RfSettings::VFO)) {
+        int64_t centreFreq = rfSettings.getCentreFrequency();
+        int64_t vfo = rfSettings.getVfo();
+        if (isFrequencyWithinNyquist(centreFreq, vfo, m_mode)) {
+          int32_t offset = centreFreq - vfo;
+          m_oscillatorMixer.setFrequency(offset);
+        }
+      }
+    }
+    if (settings->hasSettingChanged(PipelineSettings::MODE)) {
+      setMode(settings->getMode());
+    }
+  }
 }

--- a/dsp/pipeline/IqPipeline.cpp
+++ b/dsp/pipeline/IqPipeline.cpp
@@ -31,10 +31,8 @@ IqPipeline::apply(const PipelineSettings* settings)
           || rfSettings.hasSettingChanged(RfSettings::VFO)) {
         int64_t centreFreq = rfSettings.getCentreFrequency();
         int64_t vfo = rfSettings.getVfo();
-        if (isFrequencyWithinNyquist(centreFreq, vfo, m_mode)) {
-          int32_t offset = centreFreq - vfo;
-          m_oscillatorMixer.setFrequency(offset);
-        }
+        auto offset = static_cast<int32_t>(centreFreq - vfo);
+        m_oscillatorMixer.setFrequency(offset);
       }
     }
     if (settings->hasSettingChanged(PipelineSettings::MODE)) {

--- a/dsp/pipeline/IqPipeline.h
+++ b/dsp/pipeline/IqPipeline.h
@@ -10,9 +10,11 @@
 #include "io/iq/IqIo.h"
 #include "settings/Mode.h"
 #include "../../io/control/PttSink.h"
+#include "oscillators/OscillatorMixer.h"
 #include <qcoreevent.h>
 
 
+class PipelineSettings;
 class ModeSettings;
 
 class IqPipeline : public IqSink, public PttSink
@@ -32,11 +34,14 @@ public:
 
   [[nodiscard]] virtual uint32_t getMaxFramesPerInputPacket() const = 0;
   [[nodiscard]] virtual uint32_t getMaxFramesPerOutputPacket() const = 0;
+  virtual bool isFrequencyWithinNyquist(int64_t centreFrequency, int64_t frequency, const Mode& mode) const = 0;
 
   virtual void setMode(const Mode& mode)
   {
     m_mode = mode;
   }
+
+  virtual void apply(const PipelineSettings* settings);
 
 protected:
   void addStage(IqPipelineStage* pStage)
@@ -56,4 +61,5 @@ protected:
   uint32_t m_inputSampleRate;
   uint32_t m_outputSampleRate;
   AudioSink* m_pAudioOutSink;
+  OscillatorMixer m_oscillatorMixer;
 };

--- a/dsp/pipeline/IqPipeline.h
+++ b/dsp/pipeline/IqPipeline.h
@@ -13,6 +13,8 @@
 #include "oscillators/OscillatorMixer.h"
 #include <qcoreevent.h>
 
+#include "settings/RfSettings.h"
+
 
 class PipelineSettings;
 class ModeSettings;
@@ -34,11 +36,18 @@ public:
 
   [[nodiscard]] virtual uint32_t getMaxFramesPerInputPacket() const = 0;
   [[nodiscard]] virtual uint32_t getMaxFramesPerOutputPacket() const = 0;
-  virtual bool isFrequencyWithinNyquist(int64_t centreFrequency, int64_t frequency, const Mode& mode) const = 0;
+  virtual void calcNyquistOffsetsLimits(int32_t* maxNegative, int32_t* maxPositive) const = 0;
 
   virtual void setMode(const Mode& mode)
   {
     m_mode = mode;
+  }
+
+  bool adjustRfSettingsToLimits(RfSettings& rfSettings) const
+  {
+    int32_t maxNegative, maxPositive;
+    calcNyquistOffsetsLimits(&maxNegative, &maxPositive);
+    return rfSettings.applyMaximumVfoOffsets(maxNegative, maxPositive);
   }
 
   virtual void apply(const PipelineSettings* settings);

--- a/dsp/pipeline/IqRxPipeline.cpp
+++ b/dsp/pipeline/IqRxPipeline.cpp
@@ -86,8 +86,11 @@ IqRxPipeline::apply(const RxPipelineSettings* settings)
   if (settings != nullptr) {
     std::lock_guard<std::mutex> lock(m_settingsMutex);
     if (settings->hasSettingChanged(PipelineSettings::RF)) {
-      if (settings->getRfSettings().hasSettingChanged(RfSettings::OFFSET)) {
-        m_oscillatorMixer.setFrequency(-settings->getRfSettings().getOffset());
+      const RfSettings& rfSettings = settings->getRfSettings();
+      if (rfSettings.hasSettingChanged(RfSettings::CENTER_FREQUENCY)
+          || rfSettings.hasSettingChanged(RfSettings::VFO)) {
+        int32_t offset = rfSettings.getCentreFrequency() - rfSettings.getVfo();
+        m_oscillatorMixer.setFrequency(offset);
       }
     }
     if (settings->hasSettingChanged(PipelineSettings::MODE)) {

--- a/dsp/pipeline/IqRxPipeline.cpp
+++ b/dsp/pipeline/IqRxPipeline.cpp
@@ -83,20 +83,29 @@ IqRxPipeline::apply(const ReceiverSettings& settings)
 void
 IqRxPipeline::apply(const RxPipelineSettings* settings)
 {
-  if (settings != nullptr) {
-    std::lock_guard<std::mutex> lock(m_settingsMutex);
-    if (settings->hasSettingChanged(PipelineSettings::RF)) {
-      const RfSettings& rfSettings = settings->getRfSettings();
-      if (rfSettings.hasSettingChanged(RfSettings::CENTER_FREQUENCY)
-          || rfSettings.hasSettingChanged(RfSettings::VFO)) {
-        int32_t offset = rfSettings.getCentreFrequency() - rfSettings.getVfo();
-        m_oscillatorMixer.setFrequency(offset);
-      }
-    }
-    if (settings->hasSettingChanged(PipelineSettings::MODE)) {
-      setMode(settings->getMode());
-    }
-  }
+  IqPipeline::apply(settings);
+  // if (settings != nullptr) {
+  //   std::lock_guard<std::mutex> lock(m_settingsMutex);
+  //   if (settings->hasSettingChanged(PipelineSettings::RF)) {
+  //     const RfSettings& rfSettings = settings->getRfSettings();
+  //     if (rfSettings.hasSettingChanged(RfSettings::CENTER_FREQUENCY)
+  //         || rfSettings.hasSettingChanged(RfSettings::VFO)) {
+  //       int32_t offset = rfSettings.getCentreFrequency() - rfSettings.getVfo();
+  //       m_oscillatorMixer.setFrequency(offset);
+  //     }
+  //   }
+  //   if (settings->hasSettingChanged(PipelineSettings::MODE)) {
+  //     setMode(settings->getMode());
+  //   }
+  // }
+}
+
+bool
+IqRxPipeline::isFrequencyWithinNyquist(int64_t centreFrequency, int64_t frequency, const Mode& mode) const
+{
+  int32_t nyquist = m_inputSampleRate / 2;
+  return std::abs(centreFrequency - (frequency + mode.getHiCut())) <= nyquist
+    && std::abs(centreFrequency - (frequency + mode.getLoCut())) <= nyquist;
 }
 
 void

--- a/dsp/pipeline/IqRxPipeline.cpp
+++ b/dsp/pipeline/IqRxPipeline.cpp
@@ -100,12 +100,12 @@ IqRxPipeline::apply(const RxPipelineSettings* settings)
   // }
 }
 
-bool
-IqRxPipeline::isFrequencyWithinNyquist(int64_t centreFrequency, int64_t frequency, const Mode& mode) const
+void
+IqRxPipeline::calcNyquistOffsetsLimits(int32_t* maxNegative, int32_t* maxPositive) const
 {
-  int32_t nyquist = m_inputSampleRate / 2;
-  return std::abs(centreFrequency - (frequency + mode.getHiCut())) <= nyquist
-    && std::abs(centreFrequency - (frequency + mode.getLoCut())) <= nyquist;
+  int32_t nyquist = static_cast<int32_t>(m_inputSampleRate) / 2;
+  *maxNegative = -nyquist - m_mode.getLoCut();
+  *maxPositive = nyquist - m_mode.getHiCut();
 }
 
 void

--- a/dsp/pipeline/IqRxPipeline.h
+++ b/dsp/pipeline/IqRxPipeline.h
@@ -41,7 +41,8 @@ public:
 
   [[nodiscard]] uint32_t getMaxFramesPerInputPacket() const override;
   [[nodiscard]] uint32_t getMaxFramesPerOutputPacket() const override;
-  [[nodiscard]] bool isFrequencyWithinNyquist(int64_t centreFrequency, int64_t frequency, const Mode& mode) const override;
+  // [[nodiscard]] bool isFrequencyWithinNyquist(int64_t centreFrequency, int64_t frequency) const override;
+  void calcNyquistOffsetsLimits(int32_t* maxNegative, int32_t* maxPositive) const override;
 
   void setMode(const Mode& mode) override;
 protected:

--- a/dsp/pipeline/IqRxPipeline.h
+++ b/dsp/pipeline/IqRxPipeline.h
@@ -41,6 +41,7 @@ public:
 
   [[nodiscard]] uint32_t getMaxFramesPerInputPacket() const override;
   [[nodiscard]] uint32_t getMaxFramesPerOutputPacket() const override;
+  [[nodiscard]] bool isFrequencyWithinNyquist(int64_t centreFrequency, int64_t frequency, const Mode& mode) const override;
 
   void setMode(const Mode& mode) override;
 protected:
@@ -49,7 +50,7 @@ protected:
 protected:
   DcShift m_dcShift;
   IqCorrection m_iqCorrection;
-  OscillatorMixer m_oscillatorMixer;
+  // OscillatorMixer m_oscillatorMixer;
   Decimator m_decimator;
   BandPassFilter m_ifFilter;
   AmDemodulator m_amDemodulator;

--- a/dsp/pipeline/IqTxPipeline.cpp
+++ b/dsp/pipeline/IqTxPipeline.cpp
@@ -108,20 +108,29 @@ IqTxPipeline::apply(const TransmitterSettings& settings)
 void
 IqTxPipeline::apply(const TxPipelineSettings* settings)
 {
-  if (settings != nullptr) {
-    std::lock_guard<std::mutex> lock(m_settingsMutex);
-    if (settings->hasSettingChanged(PipelineSettings::RF)) {
-      const RfSettings& rfSettings = settings->getRfSettings();
-      if (rfSettings.hasSettingChanged(RfSettings::CENTER_FREQUENCY)
-          || rfSettings.hasSettingChanged(RfSettings::VFO)) {
-        int32_t offset = rfSettings.getCentreFrequency() - rfSettings.getVfo();
-        m_oscillatorMixer.setFrequency(offset);
-      }
-    }
-    if (settings->hasSettingChanged(PipelineSettings::MODE)) {
-      setMode(settings->getMode());
-    }
-  }
+  IqPipeline::apply(settings);
+  // if (settings != nullptr) {
+  //   std::lock_guard<std::mutex> lock(m_settingsMutex);
+  //   if (settings->hasSettingChanged(PipelineSettings::RF)) {
+  //     const RfSettings& rfSettings = settings->getRfSettings();
+  //     if (rfSettings.hasSettingChanged(RfSettings::CENTER_FREQUENCY)
+  //         || rfSettings.hasSettingChanged(RfSettings::VFO)) {
+  //       int32_t offset = rfSettings.getCentreFrequency() - rfSettings.getVfo();
+  //       m_oscillatorMixer.setFrequency(offset);
+  //     }
+  //   }
+  //   if (settings->hasSettingChanged(PipelineSettings::MODE)) {
+  //     setMode(settings->getMode());
+  //   }
+  // }
+}
+
+bool
+IqTxPipeline::isFrequencyWithinNyquist(int64_t centreFrequency, int64_t frequency, const Mode& mode) const
+{
+  int32_t nyquist = m_outputSampleRate / 2;
+  return std::abs(centreFrequency - (frequency + mode.getHiCut())) <= nyquist
+    && std::abs(centreFrequency - (frequency + mode.getLoCut())) <= nyquist;
 }
 
 void

--- a/dsp/pipeline/IqTxPipeline.cpp
+++ b/dsp/pipeline/IqTxPipeline.cpp
@@ -111,8 +111,11 @@ IqTxPipeline::apply(const TxPipelineSettings* settings)
   if (settings != nullptr) {
     std::lock_guard<std::mutex> lock(m_settingsMutex);
     if (settings->hasSettingChanged(PipelineSettings::RF)) {
-      if (settings->getRfSettings().hasSettingChanged(RfSettings::OFFSET)) {
-        m_oscillatorMixer.setFrequency(settings->getRfSettings().getOffset());
+      const RfSettings& rfSettings = settings->getRfSettings();
+      if (rfSettings.hasSettingChanged(RfSettings::CENTER_FREQUENCY)
+          || rfSettings.hasSettingChanged(RfSettings::VFO)) {
+        int32_t offset = rfSettings.getCentreFrequency() - rfSettings.getVfo();
+        m_oscillatorMixer.setFrequency(offset);
       }
     }
     if (settings->hasSettingChanged(PipelineSettings::MODE)) {

--- a/dsp/pipeline/IqTxPipeline.cpp
+++ b/dsp/pipeline/IqTxPipeline.cpp
@@ -91,6 +91,14 @@ IqTxPipeline::getMaxFramesPerOutputPacket() const
 }
 
 void
+IqTxPipeline::calcNyquistOffsetsLimits(int32_t* maxNegative, int32_t* maxPositive) const
+{
+  int32_t nyquist = static_cast<int32_t>(m_outputSampleRate) / 2;
+  *maxNegative = -nyquist - m_mode.getLoCut();
+  *maxPositive = nyquist - m_mode.getHiCut();
+}
+
+void
 IqTxPipeline::apply(const TransmitterSettings& settings)
 {
   std::lock_guard<std::mutex> lock(m_settingsMutex);
@@ -123,14 +131,6 @@ IqTxPipeline::apply(const TxPipelineSettings* settings)
   //     setMode(settings->getMode());
   //   }
   // }
-}
-
-bool
-IqTxPipeline::isFrequencyWithinNyquist(int64_t centreFrequency, int64_t frequency, const Mode& mode) const
-{
-  int32_t nyquist = m_outputSampleRate / 2;
-  return std::abs(centreFrequency - (frequency + mode.getHiCut())) <= nyquist
-    && std::abs(centreFrequency - (frequency + mode.getLoCut())) <= nyquist;
 }
 
 void

--- a/dsp/pipeline/IqTxPipeline.h
+++ b/dsp/pipeline/IqTxPipeline.h
@@ -39,7 +39,7 @@ public:
 
   [[nodiscard]] uint32_t getMaxFramesPerInputPacket() const override;
   [[nodiscard]] uint32_t getMaxFramesPerOutputPacket() const override;
-  [[nodiscard]] bool isFrequencyWithinNyquist(int64_t centreFrequency, int64_t frequency, const Mode& mode) const override;
+  void calcNyquistOffsetsLimits(int32_t* maxNegative, int32_t* maxPositive) const override;
   void setMode(const Mode& mode) override;
 protected:
   void setModulatorSampleRate(uint32_t sampleRate);

--- a/dsp/pipeline/IqTxPipeline.h
+++ b/dsp/pipeline/IqTxPipeline.h
@@ -39,6 +39,7 @@ public:
 
   [[nodiscard]] uint32_t getMaxFramesPerInputPacket() const override;
   [[nodiscard]] uint32_t getMaxFramesPerOutputPacket() const override;
+  [[nodiscard]] bool isFrequencyWithinNyquist(int64_t centreFrequency, int64_t frequency, const Mode& mode) const override;
   void setMode(const Mode& mode) override;
 protected:
   void setModulatorSampleRate(uint32_t sampleRate);
@@ -52,7 +53,7 @@ protected:
   FmModulator m_fmModulator;
   Modulator* m_pModulator;
   Resampler m_resampler;
-  OscillatorMixer m_oscillatorMixer;
+  // OscillatorMixer m_oscillatorMixer;
   BandPassFilter m_ifFilter;
   vsdrreal m_audioBuffer;
   uint32_t m_inputSampleRate;

--- a/io/control/device/FunCubeDongle/FunCubeDongle.cpp
+++ b/io/control/device/FunCubeDongle/FunCubeDongle.cpp
@@ -28,10 +28,10 @@ FunCubeDongle::applySettings(const RadioSettings& radioSettings, BandSettings* p
   if (radioSettings.hasSettingChanged(RadioSettings::BAND)) {
     // qDebug() << "  FunCubeDongle::applySettings: BAND_SETTINGS changed";
     const RfSettings& rfSettings = pBandSettings->getFocusRxRfSettings();
-    if (rfSettings.hasSettingChanged(RfSettings::CENTRE_FREQUENCY)) {
+    if (rfSettings.hasSettingChanged(RfSettings::CENTER_FREQUENCY)) {
         // qDebug() << "    FunCubeDongle::applySettings: FREQUENCY changed to " << rfSettings.frequency;
-      setFrequency(rfSettings.getFrequency());
-      setRfFilter(rfSettings.getFrequency());
+      setFrequency(rfSettings.getCentreFrequency());
+      setRfFilter(rfSettings.getCentreFrequency());
     }
     if (rfSettings.hasSettingChanged(RfSettings::GAIN)) {
       float gain = rfSettings.getGain();

--- a/io/control/device/gpio/digital/GpioBandSelector.cpp
+++ b/io/control/device/gpio/digital/GpioBandSelector.cpp
@@ -32,9 +32,8 @@ GpioBandSelector::applySettings(const RadioSettings& settings, BandSettings* pBa
 {
   if (settings.hasSettingChanged(RadioSettings::BAND)) {
     const RfSettings& rfSettings = pBandSettings->getTxRfSettings();
-    if (rfSettings.hasSettingChanged(RfSettings::CENTRE_FREQUENCY | RfSettings::OFFSET)) {
-      uint32_t frequency = rfSettings.getFrequency();
-      frequency += rfSettings.getOffset();
+    if (rfSettings.hasSettingChanged( RfSettings::VFO)) {
+      uint32_t frequency = rfSettings.getVfo();
       uint32_t output = getBandOutput(frequency);
       applyOutput(output);
     }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -93,7 +93,7 @@ MainWindow::handleReceiverIqEvent(const vsdrcomplex* data, uint32_t length, uint
   RxPipelineSettings* rxPipelineSettings = m_bandSettingsCopy.getFocusRxPipelineSettings();
   if (rxPipelineSettings != nullptr) {
     const RfSettings& rfSettings = rxPipelineSettings->getRfSettings();
-    uint32_t centreFrequency = rfSettings.getFrequency();
+    uint32_t centreFrequency = rfSettings.getCentreFrequency();
     uint32_t xMin = centreFrequency - (sampleRate / 2);
     uint32_t xMax = centreFrequency + (sampleRate / 2);
 
@@ -109,7 +109,7 @@ MainWindow::handleTransmitterIqEvent(const vsdrcomplex* data, uint32_t length, u
   TxPipelineSettings* txPipelineSettings = m_bandSettingsCopy.getTxPipelineSettings();
   if (txPipelineSettings != nullptr) {
     const RfSettings& rfSettings = txPipelineSettings->getRfSettings();
-    uint32_t centreFrequency = rfSettings.getFrequency();
+    uint32_t centreFrequency = rfSettings.getCentreFrequency();
     uint32_t xMin = centreFrequency - (sampleRate / 2);
     uint32_t xMax = centreFrequency + (sampleRate / 2);
 
@@ -150,17 +150,17 @@ MainWindow::handleRadioSettingsEvent(const RadioSettings& radioSettings, const B
     return;
   }
   RfSettings& rfSettings = rxPipelineSettings->getRfSettings();
-  bool frequencyChanged = (rfSettings.hasSettingChanged(RfSettings::Features::CENTRE_FREQUENCY)) != 0;
-  bool offsetChanged = (rfSettings.hasSettingChanged(RfSettings::Features::OFFSET)) != 0;
+  bool frequencyChanged = (rfSettings.hasSettingChanged(RfSettings::Features::CENTER_FREQUENCY)) != 0;
+  bool vfoChanged = (rfSettings.hasSettingChanged(RfSettings::Features::VFO)) != 0;
   bool modeChanged = (rxPipelineSettings->hasSettingChanged(PipelineSettings::Features::MODE)) != 0;
 
-  if (frequencyChanged || offsetChanged || modeChanged) {
-    auto centreFrequency = static_cast<int32_t>(rfSettings.getFrequency());
-    int32_t offset = rfSettings.getOffset();
-    int32_t frequencyAtOffset = centreFrequency + offset;
+  if (frequencyChanged || vfoChanged || modeChanged) {
+    auto centreFrequency = static_cast<int32_t>(rfSettings.getCentreFrequency());
+    int32_t vfo = rfSettings.getVfo();
+    // int32_t frequencyAtOffset = centreFrequency + offset;
 
     ui->centreFrequencyLcd->display(centreFrequency);
-    ui->cursorFrequencyLcd->display(frequencyAtOffset);
+    ui->cursorFrequencyLcd->display(vfo);
 
     if (m_reportedIqSampleRate > 0) {
       uint32_t xMin = centreFrequency - (m_reportedIqSampleRate / 2);
@@ -168,7 +168,7 @@ MainWindow::handleRadioSettingsEvent(const RadioSettings& radioSettings, const B
       m_pPanadapter->setSeriesXMinMax(xMin, xMax);
     }
     const Mode& mode = rxPipelineSettings->getMode();
-    m_pPanadapter->updateCursorPosition(frequencyAtOffset, mode.getLoCut(), mode.getHiCut());
+    m_pPanadapter->updateCursorPosition(vfo, mode.getLoCut(), mode.getHiCut());
     updateModeButton(mode);
   }
   m_radioSettingsCopy.clearChanged();

--- a/radio/Radio.cpp
+++ b/radio/Radio.cpp
@@ -142,10 +142,12 @@ Radio::applySettings(const RadioSettings& settings, BandSettings* pBandSettings)
 
     RxPipelineSettings* rxPipelineSettings = pBandSettings->getFocusRxPipelineSettings();
     if (m_pReceiver != nullptr) {
+      m_pReceiver->adjustRfSettingsToLimits(rxPipelineSettings->getRfSettings());
       m_pReceiver->apply(rxPipelineSettings);
     }
     TxPipelineSettings* txPipelineSettings = pBandSettings->getTxPipelineSettings();
     if (m_pTransmitter != nullptr) {
+      m_pTransmitter->adjustRfSettingsToLimits(txPipelineSettings->getRfSettings());
       m_pTransmitter->apply(txPipelineSettings);
     }
   }

--- a/radio/receiver/IqReceiver.cpp
+++ b/radio/receiver/IqReceiver.cpp
@@ -9,6 +9,8 @@
 #include "ReceiverIqEvent.h"
 #include <config/ReceiverConfig.h>
 
+#include "settings/RxPipelineSettings.h"
+
 // #define FFT_SIZE 2048
 
 
@@ -43,8 +45,22 @@ void
 IqReceiver::apply(const RxPipelineSettings* settings)
 {
   if (settings != nullptr) {
+
     m_iqPipeline.apply(settings);
   }
+}
+
+bool
+IqReceiver::adjustRfSettingsToLimits(RfSettings& rfSettings, bool onlyIfChanged) const
+{
+  if (onlyIfChanged) {
+    if (rfSettings.hasSettingChanged(RfSettings::CENTER_FREQUENCY)
+      || rfSettings.hasSettingChanged(RfSettings::VFO)) {
+      return m_iqPipeline.adjustRfSettingsToLimits(rfSettings);
+      }
+    return false;
+  }
+  return m_iqPipeline.adjustRfSettingsToLimits(rfSettings);
 }
 
 void

--- a/radio/receiver/IqReceiver.h
+++ b/radio/receiver/IqReceiver.h
@@ -35,6 +35,8 @@ public:
 
   void setMode(const Mode& mode);
 
+  bool adjustRfSettingsToLimits(RfSettings& rfSettings, bool onlyIfChanged = true) const;
+
 protected:
   // const ModeSettings& m_modeSettings;
   IqIo m_iqIo;

--- a/radio/transmitter/IqTransmitter.cpp
+++ b/radio/transmitter/IqTransmitter.cpp
@@ -50,6 +50,19 @@ IqTransmitter::apply(const TxPipelineSettings* settings)
   }
 }
 
+bool
+IqTransmitter::adjustRfSettingsToLimits(RfSettings& rfSettings, bool onlyIfChanged) const
+{
+  if (onlyIfChanged) {
+    if (rfSettings.hasSettingChanged(RfSettings::CENTER_FREQUENCY)
+      || rfSettings.hasSettingChanged(RfSettings::VFO)) {
+      return m_iqPipeline.adjustRfSettingsToLimits(rfSettings);
+      }
+    return false;
+  }
+  return m_iqPipeline.adjustRfSettingsToLimits(rfSettings);
+}
+
 void
 IqTransmitter::start() const
 {
@@ -64,7 +77,8 @@ IqTransmitter::stop() const
   m_iqIo.stop();
 }
 
-void IqTransmitter::ptt(bool on)
+void
+IqTransmitter::ptt(bool on)
 {
 
   if (on) {

--- a/radio/transmitter/IqTransmitter.h
+++ b/radio/transmitter/IqTransmitter.h
@@ -35,6 +35,8 @@ public:
   uint32_t sinkIq(const vsdrcomplex& samples, uint32_t length) override; // IqSink
   uint32_t sinkAudio(const vsdrreal& samples, uint32_t length, uint32_t numChannels) override; // AudioSink
 
+  bool adjustRfSettingsToLimits(RfSettings& rfSettings, bool onlyIfChanged = true) const;
+
 protected:
   // const ModeSettings& m_modeSettings;
   IqIo m_iqIo;

--- a/settings/Band.h
+++ b/settings/Band.h
@@ -12,8 +12,6 @@ class Band
 {
 public:
   Band() :
-    m_name(""),
-    m_label(""),
     m_lowestFrequency(0),
     m_highestFrequency(0),
     m_landingFrequency(0),
@@ -25,9 +23,9 @@ public:
   Band(
     const char* name,
     const char* label,
-    uint64_t lowestFrequency,
-    uint64_t highestFrequency,
-    uint64_t landingFrequency,
+    int64_t lowestFrequency,
+    int64_t highestFrequency,
+    int64_t landingFrequency,
     int32_t defaultMinorStep,
     int32_t defaultMajorStep,
     Mode::Type defaultMode
@@ -70,13 +68,13 @@ public:
     return *this;
   }
 
-  bool isValid() const { return m_name.size() > 0; }
+  [[nodiscard]] bool isValid() const { return !m_name.empty(); }
 
-  const std::string& getName() const { return m_name; }
-  const std::string& getLabel() const { return m_label; }
-  [[nodiscard]] uint64_t getLowestFrequency() const { return m_lowestFrequency; }
-  [[nodiscard]] uint64_t getHighestFrequency() const { return m_highestFrequency; }
-  [[nodiscard]] uint64_t getLandingFrequency() const { return m_landingFrequency; }
+  [[nodiscard]] const std::string& getName() const { return m_name; }
+  [[nodiscard]] const std::string& getLabel() const { return m_label; }
+  [[nodiscard]] int64_t getLowestFrequency() const { return m_lowestFrequency; }
+  [[nodiscard]] int64_t getHighestFrequency() const { return m_highestFrequency; }
+  [[nodiscard]] int64_t getLandingFrequency() const { return m_landingFrequency; }
   [[nodiscard]] int32_t getDefaultFineStep() const { return m_defaultFineStep; }
   [[nodiscard]] int32_t getDefaultCoarseStep() const { return m_defaultCoarseStep; }
   [[nodiscard]] Mode::Type getDefaultMode() const { return m_defaultMode; }
@@ -89,9 +87,9 @@ public:
 protected:
   std::string m_name;
   std::string m_label;
-  uint64_t m_lowestFrequency;
-  uint64_t m_highestFrequency;
-  uint64_t m_landingFrequency;
+  int64_t m_lowestFrequency;
+  int64_t m_highestFrequency;
+  int64_t m_landingFrequency;
   int32_t m_defaultFineStep;
   int32_t m_defaultCoarseStep;
   Mode::Type m_defaultMode;

--- a/settings/BandSettings.h
+++ b/settings/BandSettings.h
@@ -94,7 +94,7 @@ public:
   [[nodiscard]] bool hasRxFrequencyChanged() const
   {
     const RfSettings& rfSettings = getFocusRxRfSettings();
-    return rfSettings.hasSettingChanged(RfSettings::CENTRE_FREQUENCY);
+    return rfSettings.hasSettingChanged(RfSettings::CENTER_FREQUENCY);
   }
 
   void addRxPipeline()
@@ -103,7 +103,7 @@ public:
     RxPipelineSettings& newRxPipeline = m_rxPipelineSettings.back();
     RxPipelineSettings& firstRxPipeline = m_rxPipelineSettings.front();
     newRxPipeline = firstRxPipeline; // (Copy settings)
-    newRxPipeline.getRfSettings().setOffset(10000); // Move the new pipeline to the centre frequency.
+    newRxPipeline.getRfSettings().setVfo(10000); // Move the new pipeline to the centre frequency.
     m_focusRxPipeline(m_rxPipelineSettings.size() - 1); // The new pipeline gets focus
     m_changed |= RX_PIPELINE;
   }

--- a/settings/PipelineSettings.h
+++ b/settings/PipelineSettings.h
@@ -7,7 +7,6 @@
 #include "SettingsBase.h"
 #include "ModeSettings.h"
 #include <map>
-
 class PipelineSettings: public SettingsBase
 {
 public:
@@ -20,7 +19,11 @@ public:
     ALL = static_cast<uint32_t>(~0U)
   };
 
-  PipelineSettings() : m_fineStep(this, "fine-step", false) {}
+  PipelineSettings() :
+    m_fineStep(this, "fine-step", false)
+  {
+  }
+
   PipelineSettings(const PipelineSettings& rhs) :
     SettingsBase(rhs),
     m_mode(rhs.m_mode),
@@ -138,27 +141,29 @@ public:
     }
     uint32_t feature = update.getCurrentFeature();
 
+    bool settingChange = false;
     switch (feature) {
     case RF:
-      update.stepNextFeature();
-      if (m_rfSettings.applyUpdate(update)) {
+      settingChange = m_rfSettings.applyUpdate(update.stepNextFeature());
+      if (settingChange) {
         m_changed |= RF;
-        return true;
       }
-      return false;
+      break;
     case MODE:
-      update.stepNextFeature();
-      if (applyModeSetting(update)) {
+      settingChange = applyModeSetting(update.stepNextFeature());
+      if (settingChange) {
         m_changed |= MODE;
-        return true;
       }
-      return false;
+      break;
     case FINE_STEP: {
       const auto& val = update.getValue();
-      return m_fineStep.apply(val);
+      settingChange =  m_fineStep.apply(val);
+        break;
     }
-    default: return false;
+    default: ;
     }
+
+    return settingChange;
   }
 
   static bool getFeaturePath(
@@ -173,12 +178,11 @@ public:
     if (resolvePathForRegisteredSetting<PipelineSettings>(featureStrings, featuresOut, startIndex)) {
       return true;
     }
-    const std::string& key = featureStrings[startIndex];
-    if (key == "rf") {
-      featuresOut.push_back(RF);
-      return RfSettings::getFeaturePath(featureStrings, featuresOut, startIndex + 1);
+    if (RfSettings::getFeaturePath(featureStrings, featuresOut, startIndex + 1)) {
+      return true;
     }
-     if (key == "mode") {
+    const std::string& key = featureStrings[startIndex];
+    if (key == "mode") {
       featuresOut.push_back(MODE);
       return true;
     }
@@ -204,4 +208,5 @@ protected:
   ModeSettings m_modeSettings;
   RfSettings m_rfSettings;
   Setting<bool, FINE_STEP, PipelineSettings> m_fineStep;
+
 };

--- a/settings/PipelineSettings.h
+++ b/settings/PipelineSettings.h
@@ -178,10 +178,11 @@ public:
     if (resolvePathForRegisteredSetting<PipelineSettings>(featureStrings, featuresOut, startIndex)) {
       return true;
     }
-    if (RfSettings::getFeaturePath(featureStrings, featuresOut, startIndex + 1)) {
-      return true;
-    }
     const std::string& key = featureStrings[startIndex];
+    if (key == "rf") {
+      featuresOut.push_back(RF);
+      return RfSettings::getFeaturePath(featureStrings, featuresOut, startIndex + 1);
+    }
     if (key == "mode") {
       featuresOut.push_back(MODE);
       return true;

--- a/settings/RfSettings.h
+++ b/settings/RfSettings.h
@@ -53,8 +53,8 @@ public:
     return *this;
   }
 
-  [[nodiscard]] uint32_t getCentreFrequency() const { return m_centreFrequency.getValue(); }
-  [[nodiscard]] int32_t getVfo() const { return m_vfo.getValue(); }
+  [[nodiscard]] int64_t getCentreFrequency() const { return m_centreFrequency.getValue(); }
+  [[nodiscard]] int64_t getVfo() const { return m_vfo.getValue(); }
   [[nodiscard]] float getGain() const { return m_gain.getValue(); }
 
   void setCentreFrequency(uint32_t frequency)
@@ -203,8 +203,8 @@ public:
   }
 
 protected:
-  using CentreFrequencyType = SteppableSetting<uint32_t, CENTER_FREQUENCY, RfSettings, int32_t>;
-  using VfoType = SteppableSetting<int32_t, VFO, RfSettings>;
+  using CentreFrequencyType = SteppableSetting<int64_t, CENTER_FREQUENCY, RfSettings, int32_t>;
+  using VfoType = SteppableSetting<int64_t, VFO, RfSettings>;
   using GainType = SteppableSetting<float, GAIN, RfSettings>;
 
   CentreFrequencyType m_centreFrequency;

--- a/settings/RfSettings.h
+++ b/settings/RfSettings.h
@@ -11,7 +11,6 @@
 #include "SettingsBase.h"
 #include "SettingsException.h"
 #include <QDebug>
-
 #include "SteppableSetting.h"
 
 class RfSettings : public SettingsBase
@@ -30,6 +29,8 @@ public:
     ,m_centreFrequency(this, "center-frequency", 0, 10000, 50000)
     ,m_vfo(this, "vfo", 0, 100, 1000)
     ,m_gain(this, "gain", 0.0, 0.1, 1.0)
+    ,m_maxNegativeVfoOffset(0)
+    ,m_maxPositiveVfoOffset(0)
   {
   }
   RfSettings(const RfSettings& rhs) :
@@ -37,6 +38,8 @@ public:
     ,m_centreFrequency(this, "center-frequency", 0, 10000, 50000)
     ,m_vfo(this, "vfo", 0, 100, 1000)
     ,m_gain(this, "gain", 0.0, 0.1, 1.0)
+    ,m_maxNegativeVfoOffset(rhs.m_maxNegativeVfoOffset)
+    ,m_maxPositiveVfoOffset(rhs.m_maxPositiveVfoOffset)
   {
     merge(rhs);
   }
@@ -49,6 +52,8 @@ public:
       m_centreFrequency = rhs.m_centreFrequency;
       m_vfo = rhs.m_vfo;
       m_gain = rhs.m_gain;
+      m_maxPositiveVfoOffset = rhs.m_maxPositiveVfoOffset;
+      m_maxNegativeVfoOffset = rhs.m_maxNegativeVfoOffset;
     }
     return *this;
   }
@@ -56,6 +61,30 @@ public:
   [[nodiscard]] int64_t getCentreFrequency() const { return m_centreFrequency.getValue(); }
   [[nodiscard]] int64_t getVfo() const { return m_vfo.getValue(); }
   [[nodiscard]] float getGain() const { return m_gain.getValue(); }
+
+  void setMaximumVfoOffsets(int32_t negativeOffset, int32_t positiveOffset)
+  {
+    m_maxNegativeVfoOffset = negativeOffset;
+    m_maxPositiveVfoOffset = positiveOffset;
+  }
+
+  bool applyMaximumVfoOffsets(int32_t negativeOffset, int32_t positiveOffset)
+  {
+    setMaximumVfoOffsets(negativeOffset, positiveOffset);
+    bool changed = false;
+    int64_t centreFrequency = m_centreFrequency.getValue();
+    int64_t offset = m_vfo.getValue() - centreFrequency;
+    if (offset > m_maxPositiveVfoOffset) {
+      m_vfo.setValue(centreFrequency + m_maxPositiveVfoOffset);
+      m_changed |= VFO;
+      changed = true;
+    } else if (offset < m_maxNegativeVfoOffset) {
+      m_vfo.setValue(centreFrequency + m_maxNegativeVfoOffset);
+      m_changed |= VFO;
+      changed = true;
+    }
+    return changed;
+  }
 
   void setCentreFrequency(uint32_t frequency)
   {
@@ -170,13 +199,32 @@ public:
     uint32_t feature = update.getCurrentFeature();
     const auto& val = update.getValue();
 
+    bool frequencyChange = false;
     switch (feature) {
-    case CENTER_FREQUENCY: return m_centreFrequency.applyUpdate(update.stepNextFeature());
-    case VFO: return m_vfo.applyUpdate(update.stepNextFeature());
-    case GAIN: return m_gain.applyUpdate(update.stepNextFeature());
-    default:
-      return false;
+    case CENTER_FREQUENCY:
+      if (m_centreFrequency.applyUpdate(update)) {
+        frequencyChange = true;
+      }
+      break;
+    case VFO:
+      if (m_vfo.applyUpdate(update)) {
+        frequencyChange = true;
+      }
+      break;
+    case GAIN: return m_gain.applyUpdate(update);
+    default: ;
     }
+    // Clamp frequencies that are out of Nyquist
+    if (frequencyChange) {
+      int64_t centreFrequency = m_centreFrequency.getValue();
+      int64_t offset = m_vfo.getValue() - centreFrequency;
+      if (offset > m_maxPositiveVfoOffset) {
+        m_vfo.setValue(centreFrequency + m_maxPositiveVfoOffset);
+      } else if (offset < m_maxNegativeVfoOffset) {
+        m_vfo.setValue(centreFrequency + m_maxNegativeVfoOffset);
+      }
+    }
+    return frequencyChange;
   }
 
   static bool getFeaturePath(
@@ -203,11 +251,15 @@ public:
   }
 
 protected:
-  using CentreFrequencyType = SteppableSetting<int64_t, CENTER_FREQUENCY, RfSettings, int32_t>;
+  using CentreFrequencyType = SteppableSetting<int64_t, CENTER_FREQUENCY, RfSettings, int64_t>;
   using VfoType = SteppableSetting<int64_t, VFO, RfSettings>;
   using GainType = SteppableSetting<float, GAIN, RfSettings>;
 
   CentreFrequencyType m_centreFrequency;
   VfoType m_vfo;
   GainType m_gain;
+
+  // These could differ due to the modulation mode
+  int32_t m_maxNegativeVfoOffset;
+  int32_t m_maxPositiveVfoOffset;
 };

--- a/settings/RfSettings.h
+++ b/settings/RfSettings.h
@@ -20,22 +20,22 @@ public:
   enum Features
   {
     NONE = 0,
-    CENTRE_FREQUENCY = 0x01,
-    OFFSET = 0x02,
+    CENTER_FREQUENCY = 0x01,
+    VFO = 0x02,
     GAIN = 0x04,
     ALL = static_cast<uint32_t>(~0U)
   };
   RfSettings() :
     SettingsBase()
-    ,m_centreFrequency(this, "centre-frequency", 0, 10000, 50000)
-    ,m_offset(this, "offset", 0, 100, 1000)
+    ,m_centreFrequency(this, "center-frequency", 0, 10000, 50000)
+    ,m_vfo(this, "vfo", 0, 100, 1000)
     ,m_gain(this, "gain", 0.0, 0.1, 1.0)
   {
   }
   RfSettings(const RfSettings& rhs) :
     SettingsBase(rhs)
-    ,m_centreFrequency(this, "centre-frequency", 0, 10000, 50000)
-    ,m_offset(this, "offset", 0, 100, 1000)
+    ,m_centreFrequency(this, "center-frequency", 0, 10000, 50000)
+    ,m_vfo(this, "vfo", 0, 100, 1000)
     ,m_gain(this, "gain", 0.0, 0.1, 1.0)
   {
     merge(rhs);
@@ -47,53 +47,53 @@ public:
     if (this != &rhs) {
       SettingsBase::operator=(rhs);
       m_centreFrequency = rhs.m_centreFrequency;
-      m_offset = rhs.m_offset;
+      m_vfo = rhs.m_vfo;
       m_gain = rhs.m_gain;
     }
     return *this;
   }
 
-  [[nodiscard]] uint32_t getFrequency() const { return m_centreFrequency.getValue(); }
-  [[nodiscard]] int32_t getOffset() const { return m_offset.getValue(); }
+  [[nodiscard]] uint32_t getCentreFrequency() const { return m_centreFrequency.getValue(); }
+  [[nodiscard]] int32_t getVfo() const { return m_vfo.getValue(); }
   [[nodiscard]] float getGain() const { return m_gain.getValue(); }
 
   void setCentreFrequency(uint32_t frequency)
   {
     m_centreFrequency.setValue(frequency);
-    m_changed |= CENTRE_FREQUENCY;
+    m_changed |= CENTER_FREQUENCY;
   }
 
   void setCentreFrequencyDeltas(int32_t fine, int32_t coarse)
   {
     m_centreFrequency.setCoarseDelta(fine);
     m_centreFrequency.setCoarseDelta(coarse);
-    m_changed |= CENTRE_FREQUENCY;
+    m_changed |= CENTER_FREQUENCY;
   }
   void setCentreFrequencyCoarseDelta(int32_t delta)
   {
     m_centreFrequency.setCoarseDelta(delta);
-    m_changed |= CENTRE_FREQUENCY;
+    m_changed |= CENTER_FREQUENCY;
   }
   void setCentreFrequencyFineDelta(int32_t delta)
   {
     m_centreFrequency.setFineDelta(delta);
-    m_changed |= CENTRE_FREQUENCY;
+    m_changed |= CENTER_FREQUENCY;
   }
 
-  void setOffset(int32_t offset)
+  void setVfo(int32_t offset)
   {
-    m_offset.setValue(offset);
-    m_changed |= OFFSET;
+    m_vfo.setValue(offset);
+    m_changed |= VFO;
   }
-  void setOffsetCoarseDelta(int32_t step)
+  void setVfoCoarseDelta(int32_t step)
   {
-    m_offset.setCoarseDelta(step);
-    m_changed |= OFFSET;
+    m_vfo.setCoarseDelta(step);
+    m_changed |= VFO;
   }
-  void setOffsetFineDelta(int32_t step)
+  void setVfoFineDelta(int32_t step)
   {
-    m_offset.setFineDelta(step);
-    m_changed |= OFFSET;
+    m_vfo.setFineDelta(step);
+    m_changed |= VFO;
   }
 
   void setGain(float gain)
@@ -115,21 +115,21 @@ public:
   void copyFrequencies(const RfSettings& rhs)
   {
     m_centreFrequency.merge(rhs.m_centreFrequency);
-    m_offset.merge(rhs.m_offset);
+    m_vfo.merge(rhs.m_vfo);
   }
 
   bool applyBandDefaults(const Band& band)
   {
     if (band.isValid()) {
-      uint64_t freqPlusOffset = m_centreFrequency.getValue() + m_offset.getValue();
+      uint64_t freqPlusOffset = m_centreFrequency.getValue() + m_vfo.getValue();
       if (!band.containsFrequency(freqPlusOffset)) {
         // Adjusting 10kHz gets the landing frequency off any centre spike (in case of poor IQ correction)
         m_centreFrequency.setValue(band.getLandingFrequency() - 10000);
         // Note: The centre frequency steps need to ba a function of the sample rate (we don't want gaps
         // in what we see of the band when we step the centre frequency.
-        m_offset.setValue(10000);
-        m_offset.setCoarseDelta(band.getDefaultCoarseStep());
-        m_offset.setFineDelta(band.getDefaultFineStep());
+        m_vfo.setValue(band.getLandingFrequency());
+        m_vfo.setCoarseDelta(band.getDefaultCoarseStep());
+        m_vfo.setFineDelta(band.getDefaultFineStep());
         return true;
       }
     }
@@ -140,7 +140,7 @@ public:
   {
     SettingsBase::setAllChanged();
     m_centreFrequency.setAllChanged();
-    m_offset.setAllChanged();
+    m_vfo.setAllChanged();
     m_gain.setAllChanged();
   }
 
@@ -148,11 +148,11 @@ public:
   {
     bool changed = false;
     if (m_centreFrequency.merge(settings.m_centreFrequency, onlyChanged) ) {
-      m_changed |= CENTRE_FREQUENCY;
+      m_changed |= CENTER_FREQUENCY;
       changed = true;
     }
-    if (m_offset.merge(settings.m_offset, onlyChanged)) {
-      m_changed |= OFFSET;
+    if (m_vfo.merge(settings.m_vfo, onlyChanged)) {
+      m_changed |= VFO;
       changed = true;
     }
     if (m_gain.merge(settings.m_gain, onlyChanged)) {
@@ -171,8 +171,8 @@ public:
     const auto& val = update.getValue();
 
     switch (feature) {
-    case CENTRE_FREQUENCY: return m_centreFrequency.applyUpdate(update.stepNextFeature());
-    case OFFSET: return m_offset.applyUpdate(update.stepNextFeature());
+    case CENTER_FREQUENCY: return m_centreFrequency.applyUpdate(update.stepNextFeature());
+    case VFO: return m_vfo.applyUpdate(update.stepNextFeature());
     case GAIN: return m_gain.applyUpdate(update.stepNextFeature());
     default:
       return false;
@@ -192,7 +192,7 @@ public:
       if (CentreFrequencyType::getFeaturePath(featureStrings, out, startIndex + 1)) {
         return true;
       }
-      if (OffsetType::getFeaturePath(featureStrings, out, startIndex + 1)) {
+      if (VfoType::getFeaturePath(featureStrings, out, startIndex + 1)) {
         return true;
       }
       if (GainType::getFeaturePath(featureStrings, out, startIndex + 1)) {
@@ -203,11 +203,11 @@ public:
   }
 
 protected:
-  using CentreFrequencyType = SteppableSetting<uint32_t, CENTRE_FREQUENCY, RfSettings, int32_t>;
-  using OffsetType = SteppableSetting<int32_t, OFFSET, RfSettings>;
+  using CentreFrequencyType = SteppableSetting<uint32_t, CENTER_FREQUENCY, RfSettings, int32_t>;
+  using VfoType = SteppableSetting<int32_t, VFO, RfSettings>;
   using GainType = SteppableSetting<float, GAIN, RfSettings>;
 
   CentreFrequencyType m_centreFrequency;
-  OffsetType m_offset;
+  VfoType m_vfo;
   GainType m_gain;
 };

--- a/settings/RfSettings.h
+++ b/settings/RfSettings.h
@@ -202,12 +202,12 @@ public:
     bool frequencyChange = false;
     switch (feature) {
     case CENTER_FREQUENCY:
-      if (m_centreFrequency.applyUpdate(update)) {
+      if (m_centreFrequency.applyUpdate(update.stepNextFeature())) {
         frequencyChange = true;
       }
       break;
     case VFO:
-      if (m_vfo.applyUpdate(update)) {
+      if (m_vfo.applyUpdate(update.stepNextFeature())) {
         frequencyChange = true;
       }
       break;

--- a/settings/SettingValue.h
+++ b/settings/SettingValue.h
@@ -10,6 +10,7 @@
  */
 using SettingValue = std::variant<
   uint64_t,
+  int64_t,
   uint32_t,
   int32_t,
   Mode::Type,

--- a/settings/SettingsBase.h
+++ b/settings/SettingsBase.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <functional>
 #include <map>
 
 #include "SettingUpdate.h"

--- a/settings/SteppableSetting.h
+++ b/settings/SteppableSetting.h
@@ -4,7 +4,7 @@
 
 #pragma once
 #include "SettingsBase.h"
-template<typename ValueType, uint32_t ParentFeatureBit, typename ParentSettingsClass, typename DeltaType = ValueType>
+template<typename ValueType, uint32_t ParentFeatureBit, typename ParentClass, typename DeltaType = ValueType>
 class SteppableSetting: public SettingsBase
 {
 public:
@@ -29,7 +29,7 @@ public:
   //   m_value.setStepAddresses(m_fineDelta.getValueAddress(), m_coarseDelta.getValueAddress());
   // }
   SteppableSetting(
-    ParentSettingsClass* parent,
+    ParentClass* parent,
     const char* name,
     ValueType defaultValue,
     DeltaType defaultFineDelta,
@@ -41,10 +41,10 @@ public:
     , m_fineDelta(this, "fine-delta", defaultFineDelta)
     , m_coarseDelta(this, "coarse-delta", defaultCoarseDelta)
   {
-    SettingRegistry<ParentSettingsClass>::mapping[name] = ParentFeatureBit;
+    SettingRegistry<ParentClass>::mapping[name] = ParentFeatureBit;
     m_value.setStepAddresses(m_fineDelta.getValueAddress(), m_coarseDelta.getValueAddress());
   }
-  SteppableSetting(ParentSettingsClass* parent, const SteppableSetting& rhs) :
+  SteppableSetting(ParentClass* parent, const SteppableSetting& rhs) :
     SettingsBase(rhs),
     m_parent(parent),
     m_value(this, rhs.m_value),


### PR DESCRIPTION
Changed RfSettings::offset value to be RfSettings::vfo, with the value being the actual full frequency. The offset can be calculated from this and the centre frequency. This makes some things easier.