### PR TITLE
Cleared FatFs/USB semaphore

### DIFF
--- a/.idea/QtSettings.xml
+++ b/.idea/QtSettings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="QtSettings">
+    <option name="myCurrentProfile" value="stm32-debug" />
     <option name="mySettingsPerProfile">
       <map>
         <entry key="linux-debug">

--- a/src/app/stm32h745i/CM7/App/Src/main.cpp
+++ b/src/app/stm32h745i/CM7/App/Src/main.cpp
@@ -221,8 +221,8 @@ int main(void)
       SAFE_PRINTF("[CM7]:\tError opening config file: %u\r\n", res);
       Error_Handler();
     }
+    USB_Manager_ReleaseFatFsAccess();
   }
-
 
 	lv_demo_widgets();
 


### PR DESCRIPTION
Released FatFs/USB semaphore that was blocking the TinyUSB (tud) handler in the main loop.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release the FatFs/USB semaphore after config file access to unblock the `tud` handler in the main loop and restore USB event processing. This prevents the TinyUSB task from being starved during startup config reads.

<sup>Written for commit e96f60f5b86dd0d08636f0b5e5e48bbd75bb376c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

