### PR TITLE
FreeRTOS running on both cores

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/app/middleware/tinyusb_src"]
 	path = src/app/middleware/tinyusb_src
 	url = https://github.com/hathach/tinyusb_src.git
+[submodule "src/app/middleware/FreeRTOS-Kernel"]
+	path = src/app/middleware/FreeRTOS-Kernel
+	url = https://github.com/FreeRTOS/FreeRTOS-Kernel

--- a/.idea/QtSettings.xml
+++ b/.idea/QtSettings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="QtSettings">
-    <option name="myCurrentProfile" value="stm32-debug" />
     <option name="mySettingsPerProfile">
       <map>
         <entry key="linux-debug">

--- a/cmake/platforms/stm32h745i/CM4/CMakeLists.txt
+++ b/cmake/platforms/stm32h745i/CM4/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCE_DIR_CM4 ${PLATFORM_APP_DIR}/CM4)
 
 set(CM4_APP_DIR "${SOURCE_DIR_CM4}/App")
 set(CM4_SYS_DIR "${SOURCE_DIR_CM4}/Sys")
+set(CM4_FREERTOS_DIR "${FREERTOS_DIR}/portable/GCC/ARM_CM4F")
 
 set(STARTUP_FILE "${CM4_APP_DIR}/Src/Startup/startup_stm32h745xihx.s")
 set(LD_FILE ${SOURCE_DIR_CM4}/STM32H745XIHX_FLASH.ld)
@@ -35,6 +36,13 @@ set(LD_FILE ${SOURCE_DIR_CM4}/STM32H745XIHX_FLASH.ld)
 file(GLOB_RECURSE CM4_APP_SOURCES ${CM4_APP_DIR}/Src/*.c)
 file(GLOB_RECURSE CM4_SYS_SOURCES ${CM4_SYS_DIR}/Src/*.c)
 file(GLOB HAL_SOURCES ${HAL_SRC_DIR}/*.c)
+
+set(FREERTOS_SOURCES
+    ${FREERTOS_COMMON_SOURCES}
+    ${CMSIS_RTOS_SOURCES}
+    ${CM4_FREERTOS_DIR}/port.c
+    ${FREERTOS_MEMMANG_DIR}/heap_4.c
+)
 
 set(CM4_SOURCES
     ${COMMON_DIR}/Src/system_stm32h7xx_dualcore_boot_cm4_cm7.c
@@ -46,8 +54,21 @@ set(CM4_SOURCES
     ${CM4_SYS_SOURCES}
 )
 
-set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${DEBUG_FLAGS} -mcpu=cortex-m4 -x assembler-with-cpp --specs=nano.specs")
-set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -mfpu=fpv5-d16 -mfloat-abi=hard -mthumb -MMD -MP")
+if(USE_FREERTOS)
+    set(CM4_SOURCES
+        ${CM4_SOURCES}
+        ${FREERTOS_SOURCES}
+        ${CMSIS_RTOS_SOURCES}
+    )
+endif()
+
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${DEBUG_FLAGS} -x assembler-with-cpp --specs=nano.specs")
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -MMD -MP")
+
+add_compile_options(-mcpu=cortex-m4 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard)
+add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fpermissive>)
+
+add_link_options(-mcpu=cortex-m4 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard)
 
 add_library(CM4_STARTUP_OBJ OBJECT ${STARTUP_FILE})
 
@@ -69,6 +90,17 @@ set(INCLUDE_DIRS
     ${HAL_DIR}/Inc
     ${FATFS_DIR}/src
 )
+
+if(USE_FREERTOS)
+    set(INCLUDE_DIRS
+        ${INCLUDE_DIRS}
+        ${FREERTOS_DIR}/include
+        ${CM4_FREERTOS_DIR}
+        ${CMSIS_DIR}/Include
+        ${CMSIS_RTOS_DIR}
+        ${CMSIS_RTOS2_DIR}/Include
+    )
+endif()
 
 target_include_directories(${TARGET_CM4} PUBLIC ${INCLUDE_DIRS})
 

--- a/cmake/platforms/stm32h745i/CM7/CMakeLists.txt
+++ b/cmake/platforms/stm32h745i/CM7/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SOURCE_DIR_CM7 ${PLATFORM_APP_DIR}/CM7)
 set(CM7_DRIVERS_DIR "${SOURCE_DIR_CM7}/Drivers")
 set(CM7_APP_DIR "${SOURCE_DIR_CM7}/App")
 set(CM7_SYS_DIR "${SOURCE_DIR_CM7}/Sys")
+set(CM7_FREERTOS_DIR "${FREERTOS_DIR}/portable/GCC/ARM_CM7/r0p1")
 
 set(STARTUP_FILE "${CM7_APP_DIR}/Startup/startup_stm32h745xihx.s")
 #set(LD_FILE ${SOURCE_DIR_CM7}/STM32H745XIHX_FLASH.ld)
@@ -52,6 +53,13 @@ set(LD_FILE ${SOURCE_DIR_CM7}/STM32H745XIHX_QSPI.ld)
 file(GLOB_RECURSE CM7_APP_SOURCES ${CM7_APP_DIR}/Src/*.c ${CM7_APP_DIR}/Src/*.cpp)
 
 file(GLOB_RECURSE SYS_SOURCES ${SOURCE_DIR_CM7}/Sys/Src/*.c)
+
+set(FREERTOS_SOURCES
+    ${FREERTOS_COMMON_SOURCES}
+    ${CMSIS_RTOS_SOURCES}
+    ${CM7_FREERTOS_DIR}/port.c
+    ${FREERTOS_MEMMANG_DIR}/heap_4.c
+)
 
 set(CM7_SOURCES
     ${COMMON_SOURCES}
@@ -67,22 +75,22 @@ set(CM7_SOURCES
     ${TINYUSB_SOURCES}
 )
 
-set(CM7_CPP_SOURCES
-#        ${COMMON_SOURCES}
-        ${CM7_APP_SOURCES}
-        ${HAL_SOURCES}
-#        ${BSP_SOURCES}
-#        ${FATFS_SOURCES}
-)
+if(USE_FREERTOS)
+    set(CM7_SOURCES
+        ${CM7_SOURCES}
+        ${FREERTOS_SOURCES}
+        ${CMSIS_RTOS_SOURCES}
+#        ${CMSIS_RTOS2_SOURCES}
+    )
+endif()
 
-#set_source_files_properties(${CM7_CPP_SOURCES} PROPERTIES LANGUAGE CXX)
-#set_source_files_properties(${BSP_SOURCES} ${FATFS_SOURCES} PROPERTIES LANGUAGE C)
+#set(CM7_CPP_SOURCES
+#    ${CM7_APP_SOURCES}
+#    ${HAL_SOURCES}
+#)
 
-#set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${DEBUG_FLAGS} -mcpu=cortex-m7 -x assembler-with-cpp --specs=nano.specs")
 set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} ${DEBUG_FLAGS} -x assembler-with-cpp --specs=nano.specs")
-#set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -mfpu=fpv5-d16 -mfloat-abi=hard -mthumb -MMD -MP")
 set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -MMD -MP")
-
 
 add_compile_options(-mcpu=cortex-m7 -mthumb -mfpu=fpv5-d16 -mfloat-abi=hard)
 add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fpermissive>)
@@ -114,8 +122,18 @@ set(INCLUDE_DIRS
         ${FATFS_DIR}/src
         ${TINYUSB_DIR}
         ${TINYUSB_DIR}/hw/bsp/stm32h7
-
 )
+
+if(USE_FREERTOS)
+    set(INCLUDE_DIRS
+        ${INCLUDE_DIRS}
+        ${FREERTOS_DIR}/include
+        ${CM7_FREERTOS_DIR}
+        ${CMSIS_DIR}/Include
+        ${CMSIS_RTOS_DIR}
+        ${CMSIS_RTOS2_DIR}/Include
+    )
+endif()
 
 target_include_directories(${TARGET_CM7} PUBLIC ${INCLUDE_DIRS})
 

--- a/cmake/platforms/stm32h745i/stm32h745i.cmake
+++ b/cmake/platforms/stm32h745i/stm32h745i.cmake
@@ -6,6 +6,9 @@ project(nexusdr_stm32h745i_disco C ASM)
 set(IS_STM32 ON)
 add_definitions(-DIS_STM32)
 
+set(USE_FREERTOS ON)
+add_definitions(-DUSE_FREERTOS)
+
 # These are required to prevent build platform-specific libraries from being automagically added
 # to the ld command line.
 set(CMAKE_C_STANDARD_LIBRARIES "")
@@ -21,9 +24,13 @@ set(CMSIS_DIR "${DRIVERS_DIR}/CMSIS")
 set(HAL_DIR "${DRIVERS_DIR}/STM32H7xx_HAL_Driver")
 set(THIRD_PARTY_DIR "${PLATFORM_APP_DIR}/Middlewares/Third_Party")
 set(FATFS_DIR "${THIRD_PARTY_DIR}/FatFs")
+set(CMSIS_RTOS_DIR "${THIRD_PARTY_DIR}/FreeRTOS/Source/CMSIS_RTOS_V2")
+set(CMSIS_RTOS2_DIR "${CMSIS_DIR}/RTOS2")
 set(HAL_SRC_DIR "${HAL_DIR}/Src")
 set(LVGL_DIR "${MIDDLEWARE_DIR}/lvgl")
 set(TINYUSB_DIR "${MIDDLEWARE_DIR}/tinyusb_src/src")
+set(FREERTOS_DIR "${MIDDLEWARE_DIR}/FreeRTOS-Kernel")
+set(FREERTOS_MEMMANG_DIR "${FREERTOS_DIR}/portable/MemMang")
 
 file(GLOB COMMON_SOURCES ${COMMON_DIR}/Src/*.c)
 file(GLOB HAL_SOURCES ${HAL_SRC_DIR}/*.c)
@@ -35,6 +42,12 @@ file(GLOB TINYUSB_COMMON_SOURCES ${TINYUSB_DIR}/common/*.c)
 file(GLOB TINYUSB_DEVICE_SOURCES ${TINYUSB_DIR}/device/*.c)
 file(GLOB TINYUSB_CLASS_MSC_SOURCES ${TINYUSB_DIR}/class/msc/*.c)
 file(GLOB TINYUSB_PORTABLE_SOURCES ${TINYUSB_DIR}/portable/synopsys/dwc2/*.c)
+file(GLOB FREERTOS_COMMON_SOURCES ${FREERTOS_DIR}/*.c) # Not recursive. Just grab the common kernel stuff from the root.
+file(GLOB CMSIS_RTOS_SOURCES ${CMSIS_RTOS_DIR}/*.c)
+file(GLOB CMSIS_RTOS2_SOURCES ${CMSIS_RTOS2_DIR}/Source/*.c)
+
+# FreeRTOS headers dont include extern "C" guards, so force C language
+set_source_files_properties(${FREERTOS_COMMON_SOURCES} PROPERTIES LANGUAGE C)
 
 set(TINYUSB_SOURCES
         ${TINYUSB_ROOT_SOURCES}

--- a/src/app/stm32h745i/CM4/App/Src/main.c
+++ b/src/app/stm32h745i/CM4/App/Src/main.c
@@ -23,6 +23,19 @@
 #include <stdio.h>
 #include "mpu_config.h"
 
+#ifdef USE_FREERTOS
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+#ifdef __cplusplus
+ }
+#endif
+#endif // USE_FREERTOS
+
 /** @addtogroup STM32H7xx_HAL_Examples
   * @{
   */
@@ -60,15 +73,12 @@ __attribute__((section(".dma_buffer"), aligned(32))) struct {
 #define MMCFatFs (dma_buffers.MMCFatFs)
 #define CM4_File (dma_buffers.CM4_File)
 
-#ifdef __cplusplus
-extern "C" {
-  char MMCPath[4]; /* SD card logical drive path */
-}
-#endif
+char MMCPath[4]; /* SD card logical drive path */
 
 /* Private function prototypes -----------------------------------------------*/
 static void FS_FileOperations(void);
 
+static void prvBlinkTask( void *pvParameters );
 /* Private functions ---------------------------------------------------------*/
 
 
@@ -82,6 +92,7 @@ int main(void)
   BSP_LED_Init(LED_GREEN);
   BSP_LED_Init(LED_RED);
 
+
   HAL_StatusTypeDef halRc = HAL_Init();
   if (halRc != HAL_OK) {
     Error_Handler();
@@ -94,12 +105,14 @@ int main(void)
   /* Activate HSEM notification for Cortex-M4*/
   HAL_HSEM_ActivateNotification(__HAL_HSEM_SEMID_TO_MASK(HSEM_ID_0));
 
-  /* 
+  /*
     Domain D2 goes to STOP mode (Cortex-M4 in deep-sleep) waiting for Cortex-M7 to
     perform system initialization (system clock config, external memory configuration.. )   
-  */ // Actually, commented out the next two lines to try to make USART6 available (Domain 2)
+  */
   HAL_PWREx_ClearPendingEvent();
   HAL_PWREx_EnterSTOPMode(PWR_MAINREGULATOR_ON, PWR_STOPENTRY_WFE, PWR_D2_DOMAIN);
+  BSP_LED_On(LED_RED);
+
   // Do this instead:
   // while(HAL_HSEM_IsSemTaken(HSEM_ID_0)) {
   //   // Busy wait instead of STOP mode
@@ -109,22 +122,43 @@ int main(void)
   __HAL_HSEM_CLEAR_FLAG(__HAL_HSEM_SEMID_TO_MASK(HSEM_ID_0));
   SystemCoreClockUpdate();
 
-  // UART_Config();  /* USART3 on PB10/PB11 - no conflict with USB on PA11/PA12 */
+  UART_Config();  /* USART3 on PB10/PB11 - no conflict with USB on PA11/PA12 */
 
   // BSP_LED_On(LED_GREEN);
 
   /*-1- Link the micro SD disk I/O driver */
-  if(FATFS_LinkDriver(&MMC_Driver, MMCPath) == 0)
-  {
-    SAFE_PRINTF("[CM4]:\tstarting FatFs operation....\r\n");
-    /* -2- Start the FatFs operation concurrently with CM7 */
-    // BSP_LED_On(LED_GREEN);
-    FS_FileOperations();
-    while(1)
-    {
-      BSP_LED_Toggle(LED_GREEN);
-      HAL_Delay(250);
-    }
+  // if(FATFS_LinkDriver(&MMC_Driver, MMCPath) == 0)
+  // {
+  //   SAFE_PRINTF("[CM4]:\tstarting FatFs operation....\r\n");
+  //   /* -2- Start the FatFs operation concurrently with CM7 */
+  //   // BSP_LED_On(LED_GREEN);
+  //   FS_FileOperations();
+  //   while(1)
+  //   {
+  //     BSP_LED_Toggle(LED_GREEN);
+  //     HAL_Delay(250);
+  //   }
+  // }
+#ifdef USE_FREERTOS
+  BaseType_t rc = xTaskCreate( prvBlinkTask, "Blink", configMINIMAL_STACK_SIZE*5, NULL, tskIDLE_PRIORITY, NULL );
+  if (rc == pdPASS) {
+    SAFE_PRINTF("[CM4]\txTaskCreate() succeeded\r\n");
+  } else {
+    SAFE_PRINTF("[CM4]\txTaskCreate() returned: %d", rc);
+  }
+  vTaskStartScheduler();
+#endif
+
+  for (;;) {
+
+  }
+}
+
+static void prvBlinkTask( void *pvParameters )
+{
+  for (;;) {
+    vTaskDelay(pdMS_TO_TICKS( 200 ));
+    BSP_LED_Toggle(LED_RED);
   }
 }
 

--- a/src/app/stm32h745i/CM4/Sys/Inc/FreeRTOSConfig.h
+++ b/src/app/stm32h745i/CM4/Sys/Inc/FreeRTOSConfig.h
@@ -1,0 +1,186 @@
+/*
+ * FreeRTOS Kernel V10.6.2
+ * Portion Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Portion Copyright (C) 2019 StMicroelectronics, Inc.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+/*-----------------------------------------------------------
+ * Application specific definitions.
+ *
+ * These definitions should be adjusted for your particular hardware and
+ * application requirements.
+ *
+ * THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+ * FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
+ *
+ * See http://www.freertos.org/a00110.html.
+ *----------------------------------------------------------*/
+
+/* Ensure stdint is only used by the compiler, and not the assembler. */
+#if defined(__ICCARM__) || defined(__CC_ARM) || defined(__ARMCC_VERSION) || defined(__GNUC__)
+ #include <stdint.h>
+ extern uint32_t SystemCoreClock;
+
+void vGenerateCore2Interrupt( void * xUpdatedMessageBuffer );
+#endif
+
+/*-------------------- specific defines -------------------*/
+#ifndef CMSIS_device_header
+#define CMSIS_device_header "stm32h7xx.h"
+#endif /* CMSIS_device_header */
+
+#define configENABLE_FPU            1
+#define configENABLE_MPU            0
+
+#define configUSE_PREEMPTION                    1
+#define configUSE_IDLE_HOOK                     0
+// configUSE_TICK_HOOK set to 1 for the LVGL tick handler
+#define configUSE_TICK_HOOK                     0
+#define configCPU_CLOCK_HZ                      ( SystemCoreClock )
+#define configTICK_RATE_HZ                      ( ( TickType_t ) 1000 )
+/*
+ * CMSISRTOS-v2 requires:
+ * - FreeRTOS static allocation features (configSUPPORT_STATIC_ALLOCATION == 1)
+ * - Max proiorities set to 56           (configMAX_PRIORITIES == 56)
+ * - disable the optimized task selection(configUSE_PORT_OPTIMISED_TASK_SELECTION == 0)
+ */
+
+#define configMAX_PRIORITIES                    56
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION 0
+
+#define configMINIMAL_STACK_SIZE                ( ( uint16_t ) 128 )
+#define configTOTAL_HEAP_SIZE                   ( ( size_t ) ( 20 * 1024 ) )
+#define configSUPPORT_DYNAMIC_ALLOCATION        1
+
+#define configUSE_SB_COMPLETED_CALLBACK         ( 0 )
+#define configUSE_MINI_LIST_ITEM                ( 1 )
+#define configMAX_TASK_NAME_LEN                 ( 16 )
+#define configUSE_TRACE_FACILITY                1
+#define configUSE_16_BIT_TICKS                  0
+#define configIDLE_SHOULD_YIELD                 1
+#define configUSE_MUTEXES                       1
+#define configQUEUE_REGISTRY_SIZE               8
+#define configCHECK_FOR_STACK_OVERFLOW          0
+#define configUSE_RECURSIVE_MUTEXES             1
+#define configUSE_MALLOC_FAILED_HOOK            0
+#define configUSE_APPLICATION_TASK_TAG          0
+#define configUSE_COUNTING_SEMAPHORES           1
+#define configGENERATE_RUN_TIME_STATS           0
+#define configUSE_STATS_FORMATTING_FUNCTIONS    1
+
+#define configHEAP_CLEAR_MEMORY_ON_FREE         0
+/* Defaults to size_t for backward compatibility, but can be changed
+   if lengths will always be less than the number of bytes in a size_t. */
+#define configMESSAGE_BUFFER_LENGTH_TYPE         size_t
+
+#define configSUPPORT_STATIC_ALLOCATION         1
+/* Co-routine definitions. */
+#define configUSE_CO_ROUTINES                   0
+#define configMAX_CO_ROUTINE_PRIORITIES         ( 2 )
+
+/* Software timer definitions. */
+#define configUSE_TIMERS			1
+#define configTIMER_TASK_PRIORITY               ( 2 )
+#define configTIMER_QUEUE_LENGTH                10
+#define configTIMER_TASK_STACK_DEPTH            ( configMINIMAL_STACK_SIZE * 2 )
+
+/* CMSIS-RTOS V2 flags */
+#define configUSE_OS2_THREAD_SUSPEND_RESUME  1
+#define configUSE_OS2_THREAD_ENUMERATE       1
+#define configUSE_OS2_EVENTFLAGS_FROM_ISR    1
+#define configUSE_OS2_THREAD_FLAGS           1
+#define configUSE_OS2_TIMER                  1
+#define configUSE_OS2_MUTEX                  1
+#define configTEX_S_C_B_SRAM                 ( 0x03UL )
+#define configTOTAL_MPU_REGIONS              16
+/* Set the following definitions to 1 to include the API function, or zero
+to exclude the API function. */
+#define INCLUDE_vTaskPrioritySet             1
+#define INCLUDE_uxTaskPriorityGet            1
+#define INCLUDE_vTaskDelete                  1
+#define INCLUDE_vTaskCleanUpResources        0
+#define INCLUDE_vTaskSuspend                 1
+#define INCLUDE_xTaskDelayUntil              1
+#define INCLUDE_vTaskDelay                   1
+#define INCLUDE_xTaskGetSchedulerState       1
+#define INCLUDE_xTimerPendFunctionCall       1
+#define INCLUDE_xQueueGetMutexHolder         1
+#define INCLUDE_uxTaskGetStackHighWaterMark  1
+#define INCLUDE_uxTaskGetStackHighWaterMark2 1
+#define INCLUDE_xTaskGetCurrentTaskHandle    1
+#define INCLUDE_eTaskGetState                1
+
+/*
+ * The CMSIS-RTOS V2 FreeRTOS wrapper is dependent on the heap implementation used
+ * by the application thus the correct define need to be enabled below
+ */
+#define USE_FreeRTOS_HEAP_4
+
+/* Cortex-M specific definitions. */
+#ifdef __NVIC_PRIO_BITS
+ /* __BVIC_PRIO_BITS will be specified when CMSIS is being used. */
+ #define configPRIO_BITS                        __NVIC_PRIO_BITS
+#else
+ #define configPRIO_BITS                        4        /* 15 priority levels */
+#endif
+
+/* The lowest interrupt priority that can be used in a call to a "set priority"
+function. */
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY     0xf
+
+/* The highest interrupt priority that can be used by any interrupt service
+routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT CALL
+INTERRUPT SAFE FREERTOS API FUNCTIONS FROM ANY INTERRUPT THAT HAS A HIGHER
+PRIORITY THAN THIS! (higher priorities are lower numeric values. */
+#define configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY  5
+
+/* Interrupt priorities used by the kernel port layer itself.  These are generic
+to all Cortex-M ports, and do not rely on any particular library functions. */
+#define configKERNEL_INTERRUPT_PRIORITY     ( configLIBRARY_LOWEST_INTERRUPT_PRIORITY << (8 - configPRIO_BITS) )
+/* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
+See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY  ( configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << (8 - configPRIO_BITS) )
+
+/* Normal assert() semantics without relying on the provision of an assert.h
+header file. */
+#define configASSERT( x ) if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
+
+/* Definitions that map the FreeRTOS port interrupt handlers to their CMSIS
+   standard names. */
+#define vPortSVCHandler    SVC_Handler
+#define xPortPendSVHandler PendSV_Handler
+/* IMPORTANT: After 10.3.1 update, Systick_Handler comes from NVIC (if SYS timebase = systick), otherwise from cmsis_os2.c */
+
+#define USE_CUSTOM_SYSTICK_HANDLER_IMPLEMENTATION 1
+
+#define sbSEND_COMPLETED( pxStreamBuffer ) vGenerateCore2Interrupt( pxStreamBuffer )
+
+/* Section where parameter definitions can be added (for instance, to override default ones in FreeRTOS.h) */
+
+#endif /* FREERTOS_CONFIG_H */

--- a/src/app/stm32h745i/CM4/Sys/Src/stm32h7xx_it.c
+++ b/src/app/stm32h745i/CM4/Sys/Src/stm32h7xx_it.c
@@ -21,6 +21,10 @@
 /* Includes ------------------------------------------------------------------*/
 #include "stm32h7xx_it.h"
 #include "main.h"
+#ifdef USE_FREERTOS
+#include <FreeRTOS.h>
+#include <task.h>
+#endif
 
 /** @addtogroup STM32H7xx_HAL_Examples
   * @{
@@ -107,9 +111,11 @@ void UsageFault_Handler(void)
   * @param  None
   * @retval None
   */
+#ifndef USE_FREERTOS
 void SVC_Handler(void)
 {
 }
+#endif
 
 /**
   * @brief  This function handles Debug Monitor exception.
@@ -125,18 +131,33 @@ void DebugMon_Handler(void)
   * @param  None
   * @retval None
   */
+#ifndef USE_FREERTOS
 void PendSV_Handler(void)
 {
 }
-
+#endif
 /**
   * @brief  This function handles SysTick Handler.
   * @param  None
   * @retval None
   */
+#ifdef USE_FREERTOS
+extern void xPortSysTickHandler(void);
+#endif
+
 void SysTick_Handler(void)
 {
+  /* USER CODE BEGIN SysTick_IRQn 0 */
+  /* USER CODE END SysTick_IRQn 0 */
+#ifdef USE_FREERTOS
+  if (xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED) {
+    /* Call tick handler */
+    xPortSysTickHandler();
+  }
+#endif
   HAL_IncTick();
+  /* USER CODE BEGIN SysTick_IRQn 1 */
+  /* USER CODE END SysTick_IRQn 1 */
 }
 
 /******************************************************************************/

--- a/src/app/stm32h745i/CM7/App/Src/main.cpp
+++ b/src/app/stm32h745i/CM7/App/Src/main.cpp
@@ -41,6 +41,19 @@
 #include "integer.h"
 #include "nlohmann/json.hpp"
 
+#ifdef USE_FREERTOS
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+#ifdef __cplusplus
+ }
+#endif
+#endif // USE_FREERTOS
+
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -50,6 +63,8 @@
 
 /* Private define ------------------------------------------------------------*/
 /* USER CODE BEGIN PD */
+
+#define LVGL_TASK_PRIORITY			( configMAX_PRIORITIES - 2 )
 
 #ifndef HSEM_ID_0
 #define HSEM_ID_0 (0U) /* HW semaphore 0*/
@@ -112,6 +127,8 @@
 
 char MMCPath[4]; /* SD card logical drive path */
 
+static void prvLvglTask( void *pvParameters );
+
 /**
   * @brief  The application entry point.
   * @retval int
@@ -134,6 +151,7 @@ int main(void)
   /* Wait until CPU2 boots and enters in stop mode or timeout*/
   int32_t timeout = 0xFFFF;
   while((__HAL_RCC_GET_FLAG(RCC_FLAG_D2CKRDY) != RESET) && (timeout-- > 0));
+
   if ( timeout < 0 )
   {
     Error_Handler();
@@ -156,93 +174,128 @@ int main(void)
 	BSP_QSPI_EnableMemoryMappedMode(0);
 
   UART_Config();
+  SAFE_PRINTF("[CM7]\tCPU2 timeout: %x\r\n", timeout);
   USB_Manager_Init();
 
+  LOCK_HSEM(HSEM_ID_0);
+  UNLOCK_HSEM(HSEM_ID_0);// This signals the CM4 to wake up
+
   /* Initialize MMC hardware for USB MSC access */
-  SAFE_PRINTF("[CM7]:\tInitializing eMMC...\r\n");
-  if (BSP_MMC_Init(0) != BSP_ERROR_NONE) {
-    SAFE_PRINTF("[CM7]:\tERROR: eMMC initialization failed!\r\n");
-    Error_Handler();
+  // SAFE_PRINTF("[CM7]:\tInitializing eMMC...\r\n");
+  // if (BSP_MMC_Init(0) != BSP_ERROR_NONE) {
+  //   SAFE_PRINTF("[CM7]:\tERROR: eMMC initialization failed!\r\n");
+  //   Error_Handler();
+  // }
+  // SAFE_PRINTF("[CM7]:\teMMC initialized successfully\r\n");
+  //
+  // SAFE_PRINTF("[CM7]:\tInitializing USB Device...\r\n");
+  // USB_Device_Init();
+  //
+  // /* Wait for USB enumeration */
+  // uint32_t enum_start = HAL_GetTick();
+  // while (HAL_GetTick() - enum_start < 2000) {
+  //   tud_task();
+  // }
+  // SAFE_PRINTF("[CM7]:\tUSB enumeration complete\r\n");
+
+  // if(FATFS_LinkDriver(&MMC_Driver, MMCPath) == 0) {
+  //   SAFE_PRINTF("[CM4]:\tstarting FatFs operation....\r\n");
+  //   /* Request FatFs access (will block if USB is connected) */
+  //   if (USB_Manager_RequestFatFsAccess() != 0)
+  //   {
+  //     SAFE_PRINTF("[CM7]:\tFailed to mount FatFs\r\n");
+  //     Error_Handler();
+  //   }
+  //   SAFE_PRINTF("[CM7]:\tMounted FatFs\r\n");
+  //   FIL configFile;
+  //   FRESULT res = f_open(&configFile, "nexusdr.json", FA_READ);
+  //   SAFE_PRINTF("[CM7]:\tReturned from f_open()\r\n");
+  //   if(res == FR_OK)
+  //   {
+  //     UINT bytesRead;
+  //     uint8_t configJson[1024];
+  //     res = f_read(&configFile, configJson, sizeof(configJson), &bytesRead);
+  //     if((bytesRead > 0) || (res == FR_OK))
+  //     {
+  //       std::string jsonString(reinterpret_cast<const char*>(configJson));
+  //       nlohmann::json config = nlohmann::json::parse(jsonString);
+  //       if (config.contains("testMessage")) {
+  //         SAFE_PRINTF("[CM7]:\tTest message: %s\r\n", config["testMessage"].get<std::string>().c_str());
+  //       } else {
+  //         SAFE_PRINTF("[CM7]:\tNo test message found in config file\r\n");
+  //       }
+  //     } else {
+  //       SAFE_PRINTF("[CM7]:\tError reading config file: %u\r\n", res);
+  //       Error_Handler();
+  //     }
+  //
+  //     f_close(&configFile);
+  //   } else {
+  //     SAFE_PRINTF("[CM7]:\tError opening config file: %u\r\n", res);
+  //     Error_Handler();
+  //   }
+  //   USB_Manager_ReleaseFatFsAccess();
+  // }
+
+	/* Toggle LEDs to show demo loaded */
+	BSP_LED_Off(LED1);
+
+  // /* AIEC Common configuration: make CPU1 and CPU2 SWI line0
+  // sensitive to rising edge : Configured only once */
+  // HAL_EXTI_EdgeConfig(EXTI_LINE0 , EXTI_RISING_EDGE);
+  // /* USER CODE END 2 */
+#ifdef USE_FREERTOS
+  BaseType_t rc = xTaskCreate( prvLvglTask, "LVGL", 2048, NULL, LVGL_TASK_PRIORITY, NULL );
+  if (rc == pdPASS) {
+    SAFE_PRINTF("[CM7]\txTaskCreate() succeeded\r\n");
+  } else {
+    SAFE_PRINTF("[CM7]\txTaskCreate() returned: %d", rc);
   }
-  SAFE_PRINTF("[CM7]:\teMMC initialized successfully\r\n");
+  vTaskStartScheduler();
 
-  SAFE_PRINTF("[CM7]:\tInitializing USB Device...\r\n");
-  USB_Device_Init();
+#endif
+  /* Infinite loop (never reached because vTaskStartScheduler() never returns)*/
+  /* USER CODE BEGIN WHILE */
+	while (1)
+	{
+	  // HAL_Delay(500);
+	  //vTaskDelay(pdMS_TO_TICKS(500));
+    /* USER CODE END WHILE */
 
-  /* Wait for USB enumeration */
-  uint32_t enum_start = HAL_GetTick();
-  while (HAL_GetTick() - enum_start < 2000) {
-    tud_task();
-  }
-  SAFE_PRINTF("[CM7]:\tUSB enumeration complete\r\n");
+    /* USER CODE BEGIN 3 */
+#ifndef USE_FREERTOS
+		 tud_task();  // CRITICAL: Process USB events - must be called frequently!
+		 lv_timer_handler();
+#endif
+	}
+  /* USER CODE END 3 */
+}
 
-  /* Initialize LVGL and LCD */
+// void vApplicationTickHook(void)
+// {
+//   /* Calls lv_tick_inc with 1ms increment */
+//   // lv_tick_inc(1);
+//   // BSP_LED_On(LED2);
+//   HAL_IncTick();
+// }
+
+static void prvLvglTask( void *pvParameters )
+{
   SAFE_PRINTF("[CM7]:\tInitializing LVGL and LCD...\r\n");
   lv_init();
   lv_tick_set_cb(HAL_GetTick);
   LCD_init();
   SAFE_PRINTF("[CM7]:\tLCD initialized\r\n");
 
-	touchpad_init();
+  touchpad_init();
 
-  if(FATFS_LinkDriver(&MMC_Driver, MMCPath) == 0) {
-    SAFE_PRINTF("[CM4]:\tstarting FatFs operation....\r\n");
-    /* Request FatFs access (will block if USB is connected) */
-    if (USB_Manager_RequestFatFsAccess() != 0)
-    {
-      SAFE_PRINTF("[CM7]:\tFailed to mount FatFs\r\n");
-      Error_Handler();
-    }
-    SAFE_PRINTF("[CM7]:\tMounted FatFs\r\n");
-    FIL configFile;
-    FRESULT res = f_open(&configFile, "nexusdr.json", FA_READ);
-    SAFE_PRINTF("[CM7]:\tReturned from f_open()\r\n");
-    if(res == FR_OK)
-    {
-      UINT bytesRead;
-      uint8_t configJson[1024];
-      res = f_read(&configFile, configJson, sizeof(configJson), &bytesRead);
-      if((bytesRead > 0) || (res == FR_OK))
-      {
-        std::string jsonString(reinterpret_cast<const char*>(configJson));
-        nlohmann::json config = nlohmann::json::parse(jsonString);
-        if (config.contains("testMessage")) {
-          SAFE_PRINTF("[CM7]:\tTest message: %s\r\n", config["testMessage"].get<std::string>().c_str());
-        } else {
-          SAFE_PRINTF("[CM7]:\tNo test message found in config file\r\n");
-        }
-      } else {
-        SAFE_PRINTF("[CM7]:\tError reading config file: %u\r\n", res);
-        Error_Handler();
-      }
-
-      f_close(&configFile);
-    } else {
-      SAFE_PRINTF("[CM7]:\tError opening config file: %u\r\n", res);
-      Error_Handler();
-    }
-    USB_Manager_ReleaseFatFsAccess();
+  lv_demo_widgets();
+  for (;;) {
+    // tud_task();  // Here just for now
+    lv_timer_handler();
+    lv_sleep_ms(10);
+    // BSP_LED_Toggle(LED2);
   }
-
-	lv_demo_widgets();
-
-	/* Toggle LEDs to show demo loaded */
-	BSP_LED_Off(LED1);
-  /* USER CODE END 2 */
-
-  /* Infinite loop */
-  /* USER CODE BEGIN WHILE */
-	while (1)
-	{
-    /* USER CODE END WHILE */
-
-    /* USER CODE BEGIN 3 */
-
-		tud_task();  // CRITICAL: Process USB events - must be called frequently!
-		lv_timer_handler();
-	  // HAL_Delay(2);
-	}
-  /* USER CODE END 3 */
 }
 
 

--- a/src/app/stm32h745i/CM7/Sys/Inc/FreeRTOSConfig.h
+++ b/src/app/stm32h745i/CM7/Sys/Inc/FreeRTOSConfig.h
@@ -1,0 +1,186 @@
+/*
+ * FreeRTOS Kernel V10.6.2
+ * Portion Copyright (C) 2017 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Portion Copyright (C) 2019 StMicroelectronics, Inc.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+/*-----------------------------------------------------------
+ * Application specific definitions.
+ *
+ * These definitions should be adjusted for your particular hardware and
+ * application requirements.
+ *
+ * THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+ * FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
+ *
+ * See http://www.freertos.org/a00110.html.
+ *----------------------------------------------------------*/
+
+/* Ensure stdint is only used by the compiler, and not the assembler. */
+#if defined(__ICCARM__) || defined(__CC_ARM) || defined(__ARMCC_VERSION) || defined(__GNUC__)
+ #include <stdint.h>
+ extern uint32_t SystemCoreClock;
+
+void vGenerateCore2Interrupt( void * xUpdatedMessageBuffer );
+#endif
+
+/*-------------------- specific defines -------------------*/
+#ifndef CMSIS_device_header
+#define CMSIS_device_header "stm32h7xx.h"
+#endif /* CMSIS_device_header */
+
+#define configENABLE_FPU            1
+#define configENABLE_MPU            0
+
+#define configUSE_PREEMPTION                    1
+#define configUSE_IDLE_HOOK                     0
+// configUSE_TICK_HOOK set to 1 for the LVGL tick handler
+#define configUSE_TICK_HOOK                     0
+#define configCPU_CLOCK_HZ                      ( SystemCoreClock )
+#define configTICK_RATE_HZ                      ( ( TickType_t ) 1000 )
+/*
+ * CMSISRTOS-v2 requires:
+ * - FreeRTOS static allocation features (configSUPPORT_STATIC_ALLOCATION == 1)
+ * - Max proiorities set to 56           (configMAX_PRIORITIES == 56)
+ * - disable the optimized task selection(configUSE_PORT_OPTIMISED_TASK_SELECTION == 0)
+ */
+
+#define configMAX_PRIORITIES                    56
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION 0
+
+#define configMINIMAL_STACK_SIZE                ( ( uint16_t ) 128 )
+#define configTOTAL_HEAP_SIZE                   ( ( size_t ) ( 20 * 1024 ) )
+#define configSUPPORT_DYNAMIC_ALLOCATION        1
+
+#define configUSE_SB_COMPLETED_CALLBACK         ( 0 )
+#define configUSE_MINI_LIST_ITEM                ( 1 )
+#define configMAX_TASK_NAME_LEN                 ( 16 )
+#define configUSE_TRACE_FACILITY                1
+#define configUSE_16_BIT_TICKS                  0
+#define configIDLE_SHOULD_YIELD                 1
+#define configUSE_MUTEXES                       1
+#define configQUEUE_REGISTRY_SIZE               8
+#define configCHECK_FOR_STACK_OVERFLOW          0
+#define configUSE_RECURSIVE_MUTEXES             1
+#define configUSE_MALLOC_FAILED_HOOK            0
+#define configUSE_APPLICATION_TASK_TAG          0
+#define configUSE_COUNTING_SEMAPHORES           1
+#define configGENERATE_RUN_TIME_STATS           0
+#define configUSE_STATS_FORMATTING_FUNCTIONS    1
+
+#define configHEAP_CLEAR_MEMORY_ON_FREE         0
+/* Defaults to size_t for backward compatibility, but can be changed
+   if lengths will always be less than the number of bytes in a size_t. */
+#define configMESSAGE_BUFFER_LENGTH_TYPE         size_t
+
+#define configSUPPORT_STATIC_ALLOCATION         1
+/* Co-routine definitions. */
+#define configUSE_CO_ROUTINES                   0
+#define configMAX_CO_ROUTINE_PRIORITIES         ( 2 )
+
+/* Software timer definitions. */
+#define configUSE_TIMERS			1
+#define configTIMER_TASK_PRIORITY               ( 2 )
+#define configTIMER_QUEUE_LENGTH                10
+#define configTIMER_TASK_STACK_DEPTH            ( configMINIMAL_STACK_SIZE * 2 )
+
+/* CMSIS-RTOS V2 flags */
+#define configUSE_OS2_THREAD_SUSPEND_RESUME  1
+#define configUSE_OS2_THREAD_ENUMERATE       1
+#define configUSE_OS2_EVENTFLAGS_FROM_ISR    1
+#define configUSE_OS2_THREAD_FLAGS           1
+#define configUSE_OS2_TIMER                  1
+#define configUSE_OS2_MUTEX                  1
+#define configTEX_S_C_B_SRAM                 ( 0x03UL )
+#define configTOTAL_MPU_REGIONS              16
+/* Set the following definitions to 1 to include the API function, or zero
+to exclude the API function. */
+#define INCLUDE_vTaskPrioritySet             1
+#define INCLUDE_uxTaskPriorityGet            1
+#define INCLUDE_vTaskDelete                  1
+#define INCLUDE_vTaskCleanUpResources        0
+#define INCLUDE_vTaskSuspend                 1
+#define INCLUDE_xTaskDelayUntil              1
+#define INCLUDE_vTaskDelay                   1
+#define INCLUDE_xTaskGetSchedulerState       1
+#define INCLUDE_xTimerPendFunctionCall       1
+#define INCLUDE_xQueueGetMutexHolder         1
+#define INCLUDE_uxTaskGetStackHighWaterMark  1
+#define INCLUDE_uxTaskGetStackHighWaterMark2 1
+#define INCLUDE_xTaskGetCurrentTaskHandle    1
+#define INCLUDE_eTaskGetState                1
+
+/*
+ * The CMSIS-RTOS V2 FreeRTOS wrapper is dependent on the heap implementation used
+ * by the application thus the correct define need to be enabled below
+ */
+#define USE_FreeRTOS_HEAP_4
+
+/* Cortex-M specific definitions. */
+#ifdef __NVIC_PRIO_BITS
+ /* __BVIC_PRIO_BITS will be specified when CMSIS is being used. */
+ #define configPRIO_BITS                        __NVIC_PRIO_BITS
+#else
+ #define configPRIO_BITS                        4        /* 15 priority levels */
+#endif
+
+/* The lowest interrupt priority that can be used in a call to a "set priority"
+function. */
+#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY     0xf
+
+/* The highest interrupt priority that can be used by any interrupt service
+routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT CALL
+INTERRUPT SAFE FREERTOS API FUNCTIONS FROM ANY INTERRUPT THAT HAS A HIGHER
+PRIORITY THAN THIS! (higher priorities are lower numeric values. */
+#define configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY  5
+
+/* Interrupt priorities used by the kernel port layer itself.  These are generic
+to all Cortex-M ports, and do not rely on any particular library functions. */
+#define configKERNEL_INTERRUPT_PRIORITY     ( configLIBRARY_LOWEST_INTERRUPT_PRIORITY << (8 - configPRIO_BITS) )
+/* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
+See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
+#define configMAX_SYSCALL_INTERRUPT_PRIORITY  ( configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << (8 - configPRIO_BITS) )
+
+/* Normal assert() semantics without relying on the provision of an assert.h
+header file. */
+#define configASSERT( x ) if( ( x ) == 0 ) { taskDISABLE_INTERRUPTS(); for( ;; ); }
+
+/* Definitions that map the FreeRTOS port interrupt handlers to their CMSIS
+   standard names. */
+#define vPortSVCHandler    SVC_Handler
+#define xPortPendSVHandler PendSV_Handler
+/* IMPORTANT: After 10.3.1 update, Systick_Handler comes from NVIC (if SYS timebase = systick), otherwise from cmsis_os2.c */
+
+#define USE_CUSTOM_SYSTICK_HANDLER_IMPLEMENTATION 1
+
+#define sbSEND_COMPLETED( pxStreamBuffer ) vGenerateCore2Interrupt( pxStreamBuffer )
+
+/* Section where parameter definitions can be added (for instance, to override default ones in FreeRTOS.h) */
+
+#endif /* FREERTOS_CONFIG_H */

--- a/src/app/stm32h745i/CM7/Sys/Src/Lvgl_Porting/lvgl_port_lcd.c
+++ b/src/app/stm32h745i/CM7/Sys/Src/Lvgl_Porting/lvgl_port_lcd.c
@@ -9,6 +9,9 @@
 /*********************
  *      INCLUDES
  *********************/
+#include <config.h>
+#include <misc_utils.h>
+
 #include "stm32h745i_discovery.h"
 #include "stm32h745i_discovery_lcd.h"
 #include "lvgl/lvgl.h"
@@ -64,12 +67,12 @@ static lv_display_t *display = NULL;
 void LCD_init(void)
 {
     /* There is only one display on STM32 */
-    if (display != NULL)
-        abort();
-
+    if (display != NULL) {
+      abort();
+    }
     /* Initialize SDRAM for LCD frame buffers */
     BSP_SDRAM_Init(0);
-
+    SAFE_PRINTF("[CM7]:\tLCD_init(): BSP_SDRAM_Init() returned.\r\n");
     /* Initialize LCD hardware (LTDC, DMA2D, I2C4 for touchscreen) */
     BSP_LCD_Init(LCD_INSTANCE, LCD_ORIENTATION_LANDSCAPE);
     BSP_LCD_SetBrightness(LCD_INSTANCE, 100);

--- a/src/app/stm32h745i/CM7/Sys/Src/stm32h7xx_it.c
+++ b/src/app/stm32h745i/CM7/Sys/Src/stm32h7xx_it.c
@@ -23,6 +23,10 @@
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
 #include <stm32h745i_discovery_sdram.h>
+#ifdef USE_FREERTOS
+#include <FreeRTOS.h>
+#include <task.h>
+#endif
 #include <tusb.h>
 
 #include "lvgl/lvgl.h"
@@ -146,6 +150,7 @@ void UsageFault_Handler(void)
 /**
   * @brief This function handles System service call via SWI instruction.
   */
+#ifndef USE_FREERTOS
 void SVC_Handler(void)
 {
   /* USER CODE BEGIN SVCall_IRQn 0 */
@@ -155,6 +160,7 @@ void SVC_Handler(void)
 
   /* USER CODE END SVCall_IRQn 1 */
 }
+#endif
 
 /**
   * @brief This function handles Debug monitor.
@@ -172,6 +178,7 @@ void DebugMon_Handler(void)
 /**
   * @brief This function handles Pendable request for system service.
   */
+#ifndef USE_FREERTOS
 void PendSV_Handler(void)
 {
   /* USER CODE BEGIN PendSV_IRQn 0 */
@@ -181,14 +188,27 @@ void PendSV_Handler(void)
 
   /* USER CODE END PendSV_IRQn 1 */
 }
+#endif
 
 /**
   * @brief This function handles System tick timer.
   */
+/* SysTick_Handler() is implemented by the FreeRTOS port.
+ */
+#ifdef USE_FREERTOS
+extern void xPortSysTickHandler(void);
+#endif
+
 void SysTick_Handler(void)
 {
   /* USER CODE BEGIN SysTick_IRQn 0 */
   /* USER CODE END SysTick_IRQn 0 */
+#ifdef USE_FREERTOS
+  if (xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED) {
+    /* Call tick handler */
+    xPortSysTickHandler();
+  }
+#endif
   HAL_IncTick();
   /* USER CODE BEGIN SysTick_IRQn 1 */
   lv_tick_inc(1);

--- a/src/app/stm32h745i/CM7/lv_conf.h
+++ b/src/app/stm32h745i/CM7/lv_conf.h
@@ -19,6 +19,10 @@
 
 #include <stdint.h>
 
+#ifdef USE_FREERTOS
+ #define LV_USE_OS LV_OS_FREERTOS
+#endif
+
 /*====================
    COLOR SETTINGS
  *====================*/

--- a/src/app/stm32h745i/Drivers/CMSIS/RTOS2/Include/cmsis_os2.h
+++ b/src/app/stm32h745i/Drivers/CMSIS/RTOS2/Include/cmsis_os2.h
@@ -1,0 +1,756 @@
+/*
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        12. June 2020
+ * $Revision:    V2.1.3
+ *
+ * Project:      CMSIS-RTOS2 API
+ * Title:        cmsis_os2.h header file
+ *
+ * Version 2.1.3
+ *    Additional functions allowed to be called from Interrupt Service Routines:
+ *    - osThreadGetId
+ * Version 2.1.2
+ *    Additional functions allowed to be called from Interrupt Service Routines:
+ *    - osKernelGetInfo, osKernelGetState
+ * Version 2.1.1
+ *    Additional functions allowed to be called from Interrupt Service Routines:
+ *    - osKernelGetTickCount, osKernelGetTickFreq
+ *    Changed Kernel Tick type to uint32_t:
+ *    - updated: osKernelGetTickCount, osDelayUntil
+ * Version 2.1.0
+ *    Support for critical and uncritical sections (nesting safe):
+ *    - updated: osKernelLock, osKernelUnlock
+ *    - added: osKernelRestoreLock
+ *    Updated Thread and Event Flags:
+ *    - changed flags parameter and return type from int32_t to uint32_t
+ * Version 2.0.0
+ *    Initial Release
+ *---------------------------------------------------------------------------*/
+ 
+#ifndef CMSIS_OS2_H_
+#define CMSIS_OS2_H_
+ 
+#ifndef __NO_RETURN
+#if   defined(__CC_ARM)
+#define __NO_RETURN __declspec(noreturn)
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#define __NO_RETURN __attribute__((__noreturn__))
+#elif defined(__GNUC__)
+#define __NO_RETURN __attribute__((__noreturn__))
+#elif defined(__ICCARM__)
+#define __NO_RETURN __noreturn
+#else
+#define __NO_RETURN
+#endif
+#endif
+ 
+#include <stdint.h>
+#include <stddef.h>
+ 
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+ 
+ 
+//  ==== Enumerations, structures, defines ====
+ 
+/// Version information.
+typedef struct {
+  uint32_t                       api;   ///< API version (major.minor.rev: mmnnnrrrr dec).
+  uint32_t                    kernel;   ///< Kernel version (major.minor.rev: mmnnnrrrr dec).
+} osVersion_t;
+ 
+/// Kernel state.
+typedef enum {
+  osKernelInactive        =  0,         ///< Inactive.
+  osKernelReady           =  1,         ///< Ready.
+  osKernelRunning         =  2,         ///< Running.
+  osKernelLocked          =  3,         ///< Locked.
+  osKernelSuspended       =  4,         ///< Suspended.
+  osKernelError           = -1,         ///< Error.
+  osKernelReserved        = 0x7FFFFFFF  ///< Prevents enum down-size compiler optimization.
+} osKernelState_t;
+ 
+/// Thread state.
+typedef enum {
+  osThreadInactive        =  0,         ///< Inactive.
+  osThreadReady           =  1,         ///< Ready.
+  osThreadRunning         =  2,         ///< Running.
+  osThreadBlocked         =  3,         ///< Blocked.
+  osThreadTerminated      =  4,         ///< Terminated.
+  osThreadError           = -1,         ///< Error.
+  osThreadReserved        = 0x7FFFFFFF  ///< Prevents enum down-size compiler optimization.
+} osThreadState_t;
+ 
+/// Priority values.
+typedef enum {
+  osPriorityNone          =  0,         ///< No priority (not initialized).
+  osPriorityIdle          =  1,         ///< Reserved for Idle thread.
+  osPriorityLow           =  8,         ///< Priority: low
+  osPriorityLow1          =  8+1,       ///< Priority: low + 1
+  osPriorityLow2          =  8+2,       ///< Priority: low + 2
+  osPriorityLow3          =  8+3,       ///< Priority: low + 3
+  osPriorityLow4          =  8+4,       ///< Priority: low + 4
+  osPriorityLow5          =  8+5,       ///< Priority: low + 5
+  osPriorityLow6          =  8+6,       ///< Priority: low + 6
+  osPriorityLow7          =  8+7,       ///< Priority: low + 7
+  osPriorityBelowNormal   = 16,         ///< Priority: below normal
+  osPriorityBelowNormal1  = 16+1,       ///< Priority: below normal + 1
+  osPriorityBelowNormal2  = 16+2,       ///< Priority: below normal + 2
+  osPriorityBelowNormal3  = 16+3,       ///< Priority: below normal + 3
+  osPriorityBelowNormal4  = 16+4,       ///< Priority: below normal + 4
+  osPriorityBelowNormal5  = 16+5,       ///< Priority: below normal + 5
+  osPriorityBelowNormal6  = 16+6,       ///< Priority: below normal + 6
+  osPriorityBelowNormal7  = 16+7,       ///< Priority: below normal + 7
+  osPriorityNormal        = 24,         ///< Priority: normal
+  osPriorityNormal1       = 24+1,       ///< Priority: normal + 1
+  osPriorityNormal2       = 24+2,       ///< Priority: normal + 2
+  osPriorityNormal3       = 24+3,       ///< Priority: normal + 3
+  osPriorityNormal4       = 24+4,       ///< Priority: normal + 4
+  osPriorityNormal5       = 24+5,       ///< Priority: normal + 5
+  osPriorityNormal6       = 24+6,       ///< Priority: normal + 6
+  osPriorityNormal7       = 24+7,       ///< Priority: normal + 7
+  osPriorityAboveNormal   = 32,         ///< Priority: above normal
+  osPriorityAboveNormal1  = 32+1,       ///< Priority: above normal + 1
+  osPriorityAboveNormal2  = 32+2,       ///< Priority: above normal + 2
+  osPriorityAboveNormal3  = 32+3,       ///< Priority: above normal + 3
+  osPriorityAboveNormal4  = 32+4,       ///< Priority: above normal + 4
+  osPriorityAboveNormal5  = 32+5,       ///< Priority: above normal + 5
+  osPriorityAboveNormal6  = 32+6,       ///< Priority: above normal + 6
+  osPriorityAboveNormal7  = 32+7,       ///< Priority: above normal + 7
+  osPriorityHigh          = 40,         ///< Priority: high
+  osPriorityHigh1         = 40+1,       ///< Priority: high + 1
+  osPriorityHigh2         = 40+2,       ///< Priority: high + 2
+  osPriorityHigh3         = 40+3,       ///< Priority: high + 3
+  osPriorityHigh4         = 40+4,       ///< Priority: high + 4
+  osPriorityHigh5         = 40+5,       ///< Priority: high + 5
+  osPriorityHigh6         = 40+6,       ///< Priority: high + 6
+  osPriorityHigh7         = 40+7,       ///< Priority: high + 7
+  osPriorityRealtime      = 48,         ///< Priority: realtime
+  osPriorityRealtime1     = 48+1,       ///< Priority: realtime + 1
+  osPriorityRealtime2     = 48+2,       ///< Priority: realtime + 2
+  osPriorityRealtime3     = 48+3,       ///< Priority: realtime + 3
+  osPriorityRealtime4     = 48+4,       ///< Priority: realtime + 4
+  osPriorityRealtime5     = 48+5,       ///< Priority: realtime + 5
+  osPriorityRealtime6     = 48+6,       ///< Priority: realtime + 6
+  osPriorityRealtime7     = 48+7,       ///< Priority: realtime + 7
+  osPriorityISR           = 56,         ///< Reserved for ISR deferred thread.
+  osPriorityError         = -1,         ///< System cannot determine priority or illegal priority.
+  osPriorityReserved      = 0x7FFFFFFF  ///< Prevents enum down-size compiler optimization.
+} osPriority_t;
+ 
+/// Entry point of a thread.
+typedef void (*osThreadFunc_t) (void *argument);
+ 
+/// Timer callback function.
+typedef void (*osTimerFunc_t) (void *argument);
+ 
+/// Timer type.
+typedef enum {
+  osTimerOnce               = 0,          ///< One-shot timer.
+  osTimerPeriodic           = 1           ///< Repeating timer.
+} osTimerType_t;
+ 
+// Timeout value.
+#define osWaitForever         0xFFFFFFFFU ///< Wait forever timeout value.
+ 
+// Flags options (\ref osThreadFlagsWait and \ref osEventFlagsWait).
+#define osFlagsWaitAny        0x00000000U ///< Wait for any flag (default).
+#define osFlagsWaitAll        0x00000001U ///< Wait for all flags.
+#define osFlagsNoClear        0x00000002U ///< Do not clear flags which have been specified to wait for.
+ 
+// Flags errors (returned by osThreadFlagsXxxx and osEventFlagsXxxx).
+#define osFlagsError          0x80000000U ///< Error indicator.
+#define osFlagsErrorUnknown   0xFFFFFFFFU ///< osError (-1).
+#define osFlagsErrorTimeout   0xFFFFFFFEU ///< osErrorTimeout (-2).
+#define osFlagsErrorResource  0xFFFFFFFDU ///< osErrorResource (-3).
+#define osFlagsErrorParameter 0xFFFFFFFCU ///< osErrorParameter (-4).
+#define osFlagsErrorISR       0xFFFFFFFAU ///< osErrorISR (-6).
+ 
+// Thread attributes (attr_bits in \ref osThreadAttr_t).
+#define osThreadDetached      0x00000000U ///< Thread created in detached mode (default)
+#define osThreadJoinable      0x00000001U ///< Thread created in joinable mode
+ 
+// Mutex attributes (attr_bits in \ref osMutexAttr_t).
+#define osMutexRecursive      0x00000001U ///< Recursive mutex.
+#define osMutexPrioInherit    0x00000002U ///< Priority inherit protocol.
+#define osMutexRobust         0x00000008U ///< Robust mutex.
+ 
+/// Status code values returned by CMSIS-RTOS functions.
+typedef enum {
+  osOK                      =  0,         ///< Operation completed successfully.
+  osError                   = -1,         ///< Unspecified RTOS error: run-time error but no other error message fits.
+  osErrorTimeout            = -2,         ///< Operation not completed within the timeout period.
+  osErrorResource           = -3,         ///< Resource not available.
+  osErrorParameter          = -4,         ///< Parameter error.
+  osErrorNoMemory           = -5,         ///< System is out of memory: it was impossible to allocate or reserve memory for the operation.
+  osErrorISR                = -6,         ///< Not allowed in ISR context: the function cannot be called from interrupt service routines.
+  osStatusReserved          = 0x7FFFFFFF  ///< Prevents enum down-size compiler optimization.
+} osStatus_t;
+ 
+ 
+/// \details Thread ID identifies the thread.
+typedef void *osThreadId_t;
+ 
+/// \details Timer ID identifies the timer.
+typedef void *osTimerId_t;
+ 
+/// \details Event Flags ID identifies the event flags.
+typedef void *osEventFlagsId_t;
+ 
+/// \details Mutex ID identifies the mutex.
+typedef void *osMutexId_t;
+ 
+/// \details Semaphore ID identifies the semaphore.
+typedef void *osSemaphoreId_t;
+ 
+/// \details Memory Pool ID identifies the memory pool.
+typedef void *osMemoryPoolId_t;
+ 
+/// \details Message Queue ID identifies the message queue.
+typedef void *osMessageQueueId_t;
+ 
+ 
+#ifndef TZ_MODULEID_T
+#define TZ_MODULEID_T
+/// \details Data type that identifies secure software modules called by a process.
+typedef uint32_t TZ_ModuleId_t;
+#endif
+ 
+ 
+/// Attributes structure for thread.
+typedef struct {
+  const char                   *name;   ///< name of the thread
+  uint32_t                 attr_bits;   ///< attribute bits
+  void                      *cb_mem;    ///< memory for control block
+  uint32_t                   cb_size;   ///< size of provided memory for control block
+  void                   *stack_mem;    ///< memory for stack
+  uint32_t                stack_size;   ///< size of stack
+  osPriority_t              priority;   ///< initial thread priority (default: osPriorityNormal)
+  TZ_ModuleId_t            tz_module;   ///< TrustZone module identifier
+  uint32_t                  reserved;   ///< reserved (must be 0)
+} osThreadAttr_t;
+ 
+/// Attributes structure for timer.
+typedef struct {
+  const char                   *name;   ///< name of the timer
+  uint32_t                 attr_bits;   ///< attribute bits
+  void                      *cb_mem;    ///< memory for control block
+  uint32_t                   cb_size;   ///< size of provided memory for control block
+} osTimerAttr_t;
+ 
+/// Attributes structure for event flags.
+typedef struct {
+  const char                   *name;   ///< name of the event flags
+  uint32_t                 attr_bits;   ///< attribute bits
+  void                      *cb_mem;    ///< memory for control block
+  uint32_t                   cb_size;   ///< size of provided memory for control block
+} osEventFlagsAttr_t;
+ 
+/// Attributes structure for mutex.
+typedef struct {
+  const char                   *name;   ///< name of the mutex
+  uint32_t                 attr_bits;   ///< attribute bits
+  void                      *cb_mem;    ///< memory for control block
+  uint32_t                   cb_size;   ///< size of provided memory for control block
+} osMutexAttr_t;
+ 
+/// Attributes structure for semaphore.
+typedef struct {
+  const char                   *name;   ///< name of the semaphore
+  uint32_t                 attr_bits;   ///< attribute bits
+  void                      *cb_mem;    ///< memory for control block
+  uint32_t                   cb_size;   ///< size of provided memory for control block
+} osSemaphoreAttr_t;
+ 
+/// Attributes structure for memory pool.
+typedef struct {
+  const char                   *name;   ///< name of the memory pool
+  uint32_t                 attr_bits;   ///< attribute bits
+  void                      *cb_mem;    ///< memory for control block
+  uint32_t                   cb_size;   ///< size of provided memory for control block
+  void                      *mp_mem;    ///< memory for data storage
+  uint32_t                   mp_size;   ///< size of provided memory for data storage 
+} osMemoryPoolAttr_t;
+ 
+/// Attributes structure for message queue.
+typedef struct {
+  const char                   *name;   ///< name of the message queue
+  uint32_t                 attr_bits;   ///< attribute bits
+  void                      *cb_mem;    ///< memory for control block
+  uint32_t                   cb_size;   ///< size of provided memory for control block
+  void                      *mq_mem;    ///< memory for data storage
+  uint32_t                   mq_size;   ///< size of provided memory for data storage 
+} osMessageQueueAttr_t;
+ 
+ 
+//  ==== Kernel Management Functions ====
+ 
+/// Initialize the RTOS Kernel.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osKernelInitialize (void);
+ 
+///  Get RTOS Kernel Information.
+/// \param[out]    version       pointer to buffer for retrieving version information.
+/// \param[out]    id_buf        pointer to buffer for retrieving kernel identification string.
+/// \param[in]     id_size       size of buffer for kernel identification string.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osKernelGetInfo (osVersion_t *version, char *id_buf, uint32_t id_size);
+ 
+/// Get the current RTOS Kernel state.
+/// \return current RTOS Kernel state.
+osKernelState_t osKernelGetState (void);
+ 
+/// Start the RTOS Kernel scheduler.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osKernelStart (void);
+ 
+/// Lock the RTOS Kernel scheduler.
+/// \return previous lock state (1 - locked, 0 - not locked, error code if negative).
+int32_t osKernelLock (void);
+ 
+/// Unlock the RTOS Kernel scheduler.
+/// \return previous lock state (1 - locked, 0 - not locked, error code if negative).
+int32_t osKernelUnlock (void);
+ 
+/// Restore the RTOS Kernel scheduler lock state.
+/// \param[in]     lock          lock state obtained by \ref osKernelLock or \ref osKernelUnlock.
+/// \return new lock state (1 - locked, 0 - not locked, error code if negative).
+int32_t osKernelRestoreLock (int32_t lock);
+ 
+/// Suspend the RTOS Kernel scheduler.
+/// \return time in ticks, for how long the system can sleep or power-down.
+uint32_t osKernelSuspend (void);
+ 
+/// Resume the RTOS Kernel scheduler.
+/// \param[in]     sleep_ticks   time in ticks for how long the system was in sleep or power-down mode.
+void osKernelResume (uint32_t sleep_ticks);
+ 
+/// Get the RTOS kernel tick count.
+/// \return RTOS kernel current tick count.
+uint32_t osKernelGetTickCount (void);
+ 
+/// Get the RTOS kernel tick frequency.
+/// \return frequency of the kernel tick in hertz, i.e. kernel ticks per second.
+uint32_t osKernelGetTickFreq (void);
+ 
+/// Get the RTOS kernel system timer count.
+/// \return RTOS kernel current system timer count as 32-bit value.
+uint32_t osKernelGetSysTimerCount (void);
+ 
+/// Get the RTOS kernel system timer frequency.
+/// \return frequency of the system timer in hertz, i.e. timer ticks per second.
+uint32_t osKernelGetSysTimerFreq (void);
+ 
+ 
+//  ==== Thread Management Functions ====
+ 
+/// Create a thread and add it to Active Threads.
+/// \param[in]     func          thread function.
+/// \param[in]     argument      pointer that is passed to the thread function as start argument.
+/// \param[in]     attr          thread attributes; NULL: default values.
+/// \return thread ID for reference by other functions or NULL in case of error.
+osThreadId_t osThreadNew (osThreadFunc_t func, void *argument, const osThreadAttr_t *attr);
+ 
+/// Get name of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return name as null-terminated string.
+const char *osThreadGetName (osThreadId_t thread_id);
+ 
+/// Return the thread ID of the current running thread.
+/// \return thread ID for reference by other functions or NULL in case of error.
+osThreadId_t osThreadGetId (void);
+ 
+/// Get current thread state of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return current thread state of the specified thread.
+osThreadState_t osThreadGetState (osThreadId_t thread_id);
+ 
+/// Get stack size of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return stack size in bytes.
+uint32_t osThreadGetStackSize (osThreadId_t thread_id);
+ 
+/// Get available stack space of a thread based on stack watermark recording during execution.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return remaining stack space in bytes.
+uint32_t osThreadGetStackSpace (osThreadId_t thread_id);
+ 
+/// Change priority of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \param[in]     priority      new priority value for the thread function.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadSetPriority (osThreadId_t thread_id, osPriority_t priority);
+ 
+/// Get current priority of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return current priority value of the specified thread.
+osPriority_t osThreadGetPriority (osThreadId_t thread_id);
+ 
+/// Pass control to next thread that is in state \b READY.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadYield (void);
+ 
+/// Suspend execution of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadSuspend (osThreadId_t thread_id);
+ 
+/// Resume execution of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadResume (osThreadId_t thread_id);
+ 
+/// Detach a thread (thread storage can be reclaimed when thread terminates).
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadDetach (osThreadId_t thread_id);
+ 
+/// Wait for specified thread to terminate.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadJoin (osThreadId_t thread_id);
+ 
+/// Terminate execution of current running thread.
+__NO_RETURN void osThreadExit (void);
+ 
+/// Terminate execution of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osThreadTerminate (osThreadId_t thread_id);
+ 
+/// Get number of active threads.
+/// \return number of active threads.
+uint32_t osThreadGetCount (void);
+ 
+/// Enumerate active threads.
+/// \param[out]    thread_array  pointer to array for retrieving thread IDs.
+/// \param[in]     array_items   maximum number of items in array for retrieving thread IDs.
+/// \return number of enumerated threads.
+uint32_t osThreadEnumerate (osThreadId_t *thread_array, uint32_t array_items);
+ 
+ 
+//  ==== Thread Flags Functions ====
+ 
+/// Set the specified Thread Flags of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadNew or \ref osThreadGetId.
+/// \param[in]     flags         specifies the flags of the thread that shall be set.
+/// \return thread flags after setting or error code if highest bit set.
+uint32_t osThreadFlagsSet (osThreadId_t thread_id, uint32_t flags);
+ 
+/// Clear the specified Thread Flags of current running thread.
+/// \param[in]     flags         specifies the flags of the thread that shall be cleared.
+/// \return thread flags before clearing or error code if highest bit set.
+uint32_t osThreadFlagsClear (uint32_t flags);
+ 
+/// Get the current Thread Flags of current running thread.
+/// \return current thread flags.
+uint32_t osThreadFlagsGet (void);
+ 
+/// Wait for one or more Thread Flags of the current running thread to become signaled.
+/// \param[in]     flags         specifies the flags to wait for.
+/// \param[in]     options       specifies flags options (osFlagsXxxx).
+/// \param[in]     timeout       \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return thread flags before clearing or error code if highest bit set.
+uint32_t osThreadFlagsWait (uint32_t flags, uint32_t options, uint32_t timeout);
+ 
+ 
+//  ==== Generic Wait Functions ====
+ 
+/// Wait for Timeout (Time Delay).
+/// \param[in]     ticks         \ref CMSIS_RTOS_TimeOutValue "time ticks" value
+/// \return status code that indicates the execution status of the function.
+osStatus_t osDelay (uint32_t ticks);
+ 
+/// Wait until specified time.
+/// \param[in]     ticks         absolute time in ticks
+/// \return status code that indicates the execution status of the function.
+osStatus_t osDelayUntil (uint32_t ticks);
+ 
+ 
+//  ==== Timer Management Functions ====
+ 
+/// Create and Initialize a timer.
+/// \param[in]     func          function pointer to callback function.
+/// \param[in]     type          \ref osTimerOnce for one-shot or \ref osTimerPeriodic for periodic behavior.
+/// \param[in]     argument      argument to the timer callback function.
+/// \param[in]     attr          timer attributes; NULL: default values.
+/// \return timer ID for reference by other functions or NULL in case of error.
+osTimerId_t osTimerNew (osTimerFunc_t func, osTimerType_t type, void *argument, const osTimerAttr_t *attr);
+ 
+/// Get name of a timer.
+/// \param[in]     timer_id      timer ID obtained by \ref osTimerNew.
+/// \return name as null-terminated string.
+const char *osTimerGetName (osTimerId_t timer_id);
+ 
+/// Start or restart a timer.
+/// \param[in]     timer_id      timer ID obtained by \ref osTimerNew.
+/// \param[in]     ticks         \ref CMSIS_RTOS_TimeOutValue "time ticks" value of the timer.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osTimerStart (osTimerId_t timer_id, uint32_t ticks);
+ 
+/// Stop a timer.
+/// \param[in]     timer_id      timer ID obtained by \ref osTimerNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osTimerStop (osTimerId_t timer_id);
+ 
+/// Check if a timer is running.
+/// \param[in]     timer_id      timer ID obtained by \ref osTimerNew.
+/// \return 0 not running, 1 running.
+uint32_t osTimerIsRunning (osTimerId_t timer_id);
+ 
+/// Delete a timer.
+/// \param[in]     timer_id      timer ID obtained by \ref osTimerNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osTimerDelete (osTimerId_t timer_id);
+ 
+ 
+//  ==== Event Flags Management Functions ====
+ 
+/// Create and Initialize an Event Flags object.
+/// \param[in]     attr          event flags attributes; NULL: default values.
+/// \return event flags ID for reference by other functions or NULL in case of error.
+osEventFlagsId_t osEventFlagsNew (const osEventFlagsAttr_t *attr);
+ 
+/// Get name of an Event Flags object.
+/// \param[in]     ef_id         event flags ID obtained by \ref osEventFlagsNew.
+/// \return name as null-terminated string.
+const char *osEventFlagsGetName (osEventFlagsId_t ef_id);
+ 
+/// Set the specified Event Flags.
+/// \param[in]     ef_id         event flags ID obtained by \ref osEventFlagsNew.
+/// \param[in]     flags         specifies the flags that shall be set.
+/// \return event flags after setting or error code if highest bit set.
+uint32_t osEventFlagsSet (osEventFlagsId_t ef_id, uint32_t flags);
+ 
+/// Clear the specified Event Flags.
+/// \param[in]     ef_id         event flags ID obtained by \ref osEventFlagsNew.
+/// \param[in]     flags         specifies the flags that shall be cleared.
+/// \return event flags before clearing or error code if highest bit set.
+uint32_t osEventFlagsClear (osEventFlagsId_t ef_id, uint32_t flags);
+ 
+/// Get the current Event Flags.
+/// \param[in]     ef_id         event flags ID obtained by \ref osEventFlagsNew.
+/// \return current event flags.
+uint32_t osEventFlagsGet (osEventFlagsId_t ef_id);
+ 
+/// Wait for one or more Event Flags to become signaled.
+/// \param[in]     ef_id         event flags ID obtained by \ref osEventFlagsNew.
+/// \param[in]     flags         specifies the flags to wait for.
+/// \param[in]     options       specifies flags options (osFlagsXxxx).
+/// \param[in]     timeout       \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return event flags before clearing or error code if highest bit set.
+uint32_t osEventFlagsWait (osEventFlagsId_t ef_id, uint32_t flags, uint32_t options, uint32_t timeout);
+ 
+/// Delete an Event Flags object.
+/// \param[in]     ef_id         event flags ID obtained by \ref osEventFlagsNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osEventFlagsDelete (osEventFlagsId_t ef_id);
+ 
+ 
+//  ==== Mutex Management Functions ====
+ 
+/// Create and Initialize a Mutex object.
+/// \param[in]     attr          mutex attributes; NULL: default values.
+/// \return mutex ID for reference by other functions or NULL in case of error.
+osMutexId_t osMutexNew (const osMutexAttr_t *attr);
+ 
+/// Get name of a Mutex object.
+/// \param[in]     mutex_id      mutex ID obtained by \ref osMutexNew.
+/// \return name as null-terminated string.
+const char *osMutexGetName (osMutexId_t mutex_id);
+ 
+/// Acquire a Mutex or timeout if it is locked.
+/// \param[in]     mutex_id      mutex ID obtained by \ref osMutexNew.
+/// \param[in]     timeout       \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMutexAcquire (osMutexId_t mutex_id, uint32_t timeout);
+ 
+/// Release a Mutex that was acquired by \ref osMutexAcquire.
+/// \param[in]     mutex_id      mutex ID obtained by \ref osMutexNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMutexRelease (osMutexId_t mutex_id);
+ 
+/// Get Thread which owns a Mutex object.
+/// \param[in]     mutex_id      mutex ID obtained by \ref osMutexNew.
+/// \return thread ID of owner thread or NULL when mutex was not acquired.
+osThreadId_t osMutexGetOwner (osMutexId_t mutex_id);
+ 
+/// Delete a Mutex object.
+/// \param[in]     mutex_id      mutex ID obtained by \ref osMutexNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMutexDelete (osMutexId_t mutex_id);
+ 
+ 
+//  ==== Semaphore Management Functions ====
+ 
+/// Create and Initialize a Semaphore object.
+/// \param[in]     max_count     maximum number of available tokens.
+/// \param[in]     initial_count initial number of available tokens.
+/// \param[in]     attr          semaphore attributes; NULL: default values.
+/// \return semaphore ID for reference by other functions or NULL in case of error.
+osSemaphoreId_t osSemaphoreNew (uint32_t max_count, uint32_t initial_count, const osSemaphoreAttr_t *attr);
+ 
+/// Get name of a Semaphore object.
+/// \param[in]     semaphore_id  semaphore ID obtained by \ref osSemaphoreNew.
+/// \return name as null-terminated string.
+const char *osSemaphoreGetName (osSemaphoreId_t semaphore_id);
+ 
+/// Acquire a Semaphore token or timeout if no tokens are available.
+/// \param[in]     semaphore_id  semaphore ID obtained by \ref osSemaphoreNew.
+/// \param[in]     timeout       \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osSemaphoreAcquire (osSemaphoreId_t semaphore_id, uint32_t timeout);
+ 
+/// Release a Semaphore token up to the initial maximum count.
+/// \param[in]     semaphore_id  semaphore ID obtained by \ref osSemaphoreNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osSemaphoreRelease (osSemaphoreId_t semaphore_id);
+ 
+/// Get current Semaphore token count.
+/// \param[in]     semaphore_id  semaphore ID obtained by \ref osSemaphoreNew.
+/// \return number of tokens available.
+uint32_t osSemaphoreGetCount (osSemaphoreId_t semaphore_id);
+ 
+/// Delete a Semaphore object.
+/// \param[in]     semaphore_id  semaphore ID obtained by \ref osSemaphoreNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osSemaphoreDelete (osSemaphoreId_t semaphore_id);
+ 
+ 
+//  ==== Memory Pool Management Functions ====
+ 
+/// Create and Initialize a Memory Pool object.
+/// \param[in]     block_count   maximum number of memory blocks in memory pool.
+/// \param[in]     block_size    memory block size in bytes.
+/// \param[in]     attr          memory pool attributes; NULL: default values.
+/// \return memory pool ID for reference by other functions or NULL in case of error.
+osMemoryPoolId_t osMemoryPoolNew (uint32_t block_count, uint32_t block_size, const osMemoryPoolAttr_t *attr);
+ 
+/// Get name of a Memory Pool object.
+/// \param[in]     mp_id         memory pool ID obtained by \ref osMemoryPoolNew.
+/// \return name as null-terminated string.
+const char *osMemoryPoolGetName (osMemoryPoolId_t mp_id);
+ 
+/// Allocate a memory block from a Memory Pool.
+/// \param[in]     mp_id         memory pool ID obtained by \ref osMemoryPoolNew.
+/// \param[in]     timeout       \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return address of the allocated memory block or NULL in case of no memory is available.
+void *osMemoryPoolAlloc (osMemoryPoolId_t mp_id, uint32_t timeout);
+ 
+/// Return an allocated memory block back to a Memory Pool.
+/// \param[in]     mp_id         memory pool ID obtained by \ref osMemoryPoolNew.
+/// \param[in]     block         address of the allocated memory block to be returned to the memory pool.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMemoryPoolFree (osMemoryPoolId_t mp_id, void *block);
+ 
+/// Get maximum number of memory blocks in a Memory Pool.
+/// \param[in]     mp_id         memory pool ID obtained by \ref osMemoryPoolNew.
+/// \return maximum number of memory blocks.
+uint32_t osMemoryPoolGetCapacity (osMemoryPoolId_t mp_id);
+ 
+/// Get memory block size in a Memory Pool.
+/// \param[in]     mp_id         memory pool ID obtained by \ref osMemoryPoolNew.
+/// \return memory block size in bytes.
+uint32_t osMemoryPoolGetBlockSize (osMemoryPoolId_t mp_id);
+ 
+/// Get number of memory blocks used in a Memory Pool.
+/// \param[in]     mp_id         memory pool ID obtained by \ref osMemoryPoolNew.
+/// \return number of memory blocks used.
+uint32_t osMemoryPoolGetCount (osMemoryPoolId_t mp_id);
+ 
+/// Get number of memory blocks available in a Memory Pool.
+/// \param[in]     mp_id         memory pool ID obtained by \ref osMemoryPoolNew.
+/// \return number of memory blocks available.
+uint32_t osMemoryPoolGetSpace (osMemoryPoolId_t mp_id);
+ 
+/// Delete a Memory Pool object.
+/// \param[in]     mp_id         memory pool ID obtained by \ref osMemoryPoolNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMemoryPoolDelete (osMemoryPoolId_t mp_id);
+ 
+ 
+//  ==== Message Queue Management Functions ====
+ 
+/// Create and Initialize a Message Queue object.
+/// \param[in]     msg_count     maximum number of messages in queue.
+/// \param[in]     msg_size      maximum message size in bytes.
+/// \param[in]     attr          message queue attributes; NULL: default values.
+/// \return message queue ID for reference by other functions or NULL in case of error.
+osMessageQueueId_t osMessageQueueNew (uint32_t msg_count, uint32_t msg_size, const osMessageQueueAttr_t *attr);
+ 
+/// Get name of a Message Queue object.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \return name as null-terminated string.
+const char *osMessageQueueGetName (osMessageQueueId_t mq_id);
+ 
+/// Put a Message into a Queue or timeout if Queue is full.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \param[in]     msg_ptr       pointer to buffer with message to put into a queue.
+/// \param[in]     msg_prio      message priority.
+/// \param[in]     timeout       \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMessageQueuePut (osMessageQueueId_t mq_id, const void *msg_ptr, uint8_t msg_prio, uint32_t timeout);
+ 
+/// Get a Message from a Queue or timeout if Queue is empty.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \param[out]    msg_ptr       pointer to buffer for message to get from a queue.
+/// \param[out]    msg_prio      pointer to buffer for message priority or NULL.
+/// \param[in]     timeout       \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMessageQueueGet (osMessageQueueId_t mq_id, void *msg_ptr, uint8_t *msg_prio, uint32_t timeout);
+ 
+/// Get maximum number of messages in a Message Queue.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \return maximum number of messages.
+uint32_t osMessageQueueGetCapacity (osMessageQueueId_t mq_id);
+ 
+/// Get maximum message size in a Message Queue.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \return maximum message size in bytes.
+uint32_t osMessageQueueGetMsgSize (osMessageQueueId_t mq_id);
+ 
+/// Get number of queued messages in a Message Queue.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \return number of queued messages.
+uint32_t osMessageQueueGetCount (osMessageQueueId_t mq_id);
+ 
+/// Get number of available slots for messages in a Message Queue.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \return number of available slots for messages.
+uint32_t osMessageQueueGetSpace (osMessageQueueId_t mq_id);
+ 
+/// Reset a Message Queue to initial empty state.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMessageQueueReset (osMessageQueueId_t mq_id);
+ 
+/// Delete a Message Queue object.
+/// \param[in]     mq_id         message queue ID obtained by \ref osMessageQueueNew.
+/// \return status code that indicates the execution status of the function.
+osStatus_t osMessageQueueDelete (osMessageQueueId_t mq_id);
+ 
+ 
+#ifdef  __cplusplus
+}
+#endif
+ 
+#endif  // CMSIS_OS2_H_

--- a/src/app/stm32h745i/Drivers/CMSIS/RTOS2/Include/os_tick.h
+++ b/src/app/stm32h745i/Drivers/CMSIS/RTOS2/Include/os_tick.h
@@ -1,0 +1,80 @@
+/**************************************************************************//**
+ * @file     os_tick.h
+ * @brief    CMSIS OS Tick header file
+ * @version  V1.0.2
+ * @date     19. March 2021
+ ******************************************************************************/
+/*
+ * Copyright (c) 2017-2021 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef OS_TICK_H
+#define OS_TICK_H
+
+#include <stdint.h>
+
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+
+/// IRQ Handler.
+#ifndef IRQHANDLER_T
+#define IRQHANDLER_T
+typedef void (*IRQHandler_t) (void);
+#endif
+
+/// Setup OS Tick timer to generate periodic RTOS Kernel Ticks
+/// \param[in]     freq         tick frequency in Hz
+/// \param[in]     handler      tick IRQ handler
+/// \return 0 on success, -1 on error.
+int32_t  OS_Tick_Setup (uint32_t freq, IRQHandler_t handler);
+
+/// Enable OS Tick timer interrupt
+void     OS_Tick_Enable (void);
+
+/// Disable OS Tick timer interrupt
+void     OS_Tick_Disable (void);
+
+/// Acknowledge execution of OS Tick timer interrupt
+void     OS_Tick_AcknowledgeIRQ (void);
+
+/// Get OS Tick timer IRQ number
+/// \return OS Tick IRQ number
+int32_t  OS_Tick_GetIRQn (void);
+
+/// Get OS Tick timer clock frequency
+/// \return OS Tick timer clock frequency in Hz
+uint32_t OS_Tick_GetClock (void);
+
+/// Get OS Tick timer interval reload value
+/// \return OS Tick timer interval reload value
+uint32_t OS_Tick_GetInterval (void);
+
+/// Get OS Tick timer counter value
+/// \return OS Tick timer counter value
+uint32_t OS_Tick_GetCount (void);
+
+/// Get OS Tick timer overflow status
+/// \return OS Tick overflow status (1 - overflow, 0 - no overflow).
+uint32_t OS_Tick_GetOverflow (void);
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif  /* OS_TICK_H */

--- a/src/app/stm32h745i/Drivers/CMSIS/RTOS2/Source/os_systick.c
+++ b/src/app/stm32h745i/Drivers/CMSIS/RTOS2/Source/os_systick.c
@@ -1,0 +1,133 @@
+/**************************************************************************//**
+ * @file     os_systick.c
+ * @brief    CMSIS OS Tick SysTick implementation
+ * @version  V1.0.3
+ * @date     19. March 2021
+ ******************************************************************************/
+/*
+ * Copyright (c) 2017-2021 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "os_tick.h"
+
+//lint -emacro((923,9078),SCB,SysTick) "cast from unsigned long to pointer"
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+#ifdef  SysTick
+
+#ifndef SYSTICK_IRQ_PRIORITY
+#define SYSTICK_IRQ_PRIORITY    0xFFU
+#endif
+
+static uint8_t PendST __attribute__((section(".bss.os")));
+
+// Setup OS Tick.
+__WEAK int32_t OS_Tick_Setup (uint32_t freq, IRQHandler_t handler) {
+  uint32_t load;
+  (void)handler;
+
+  if (freq == 0U) {
+    //lint -e{904} "Return statement before end of function"
+    return (-1);
+  }
+
+  load = (SystemCoreClock / freq) - 1U;
+  if (load > 0x00FFFFFFU) {
+    //lint -e{904} "Return statement before end of function"
+    return (-1);
+  }
+
+  // Set SysTick Interrupt Priority
+#if   ((defined(__ARM_ARCH_8M_MAIN__)   && (__ARM_ARCH_8M_MAIN__   != 0)) || \
+       (defined(__ARM_ARCH_8_1M_MAIN__) && (__ARM_ARCH_8_1M_MAIN__ != 0)) || \
+       (defined(__CORTEX_M)             && (__CORTEX_M             == 7U)))
+  SCB->SHPR[11] = SYSTICK_IRQ_PRIORITY;
+#elif  (defined(__ARM_ARCH_8M_BASE__)   && (__ARM_ARCH_8M_BASE__   != 0))
+  SCB->SHPR[1] |= ((uint32_t)SYSTICK_IRQ_PRIORITY << 24);
+#elif ((defined(__ARM_ARCH_7M__)        && (__ARM_ARCH_7M__        != 0)) || \
+       (defined(__ARM_ARCH_7EM__)       && (__ARM_ARCH_7EM__       != 0)))
+  SCB->SHP[11]  = SYSTICK_IRQ_PRIORITY;
+#elif  (defined(__ARM_ARCH_6M__)        && (__ARM_ARCH_6M__        != 0))
+  SCB->SHP[1]  |= ((uint32_t)SYSTICK_IRQ_PRIORITY << 24);
+#else
+#error "Unknown ARM Core!"
+#endif
+
+  SysTick->CTRL =  SysTick_CTRL_CLKSOURCE_Msk | SysTick_CTRL_TICKINT_Msk;
+  SysTick->LOAD =  load;
+  SysTick->VAL  =  0U;
+
+  PendST = 0U;
+
+  return (0);
+}
+
+/// Enable OS Tick.
+__WEAK void OS_Tick_Enable (void) {
+
+  if (PendST != 0U) {
+    PendST = 0U;
+    SCB->ICSR = SCB_ICSR_PENDSTSET_Msk;
+  }
+
+  SysTick->CTRL |=  SysTick_CTRL_ENABLE_Msk;
+}
+
+/// Disable OS Tick.
+__WEAK void OS_Tick_Disable (void) {
+
+  SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
+
+  if ((SCB->ICSR & SCB_ICSR_PENDSTSET_Msk) != 0U) {
+    SCB->ICSR = SCB_ICSR_PENDSTCLR_Msk;
+    PendST = 1U;
+  }
+}
+
+// Acknowledge OS Tick IRQ.
+__WEAK void OS_Tick_AcknowledgeIRQ (void) {
+  (void)SysTick->CTRL;
+}
+
+// Get OS Tick IRQ number.
+__WEAK int32_t  OS_Tick_GetIRQn (void) {
+  return ((int32_t)SysTick_IRQn);
+}
+
+// Get OS Tick clock.
+__WEAK uint32_t OS_Tick_GetClock (void) {
+  return (SystemCoreClock);
+}
+
+// Get OS Tick interval.
+__WEAK uint32_t OS_Tick_GetInterval (void) {
+  return (SysTick->LOAD + 1U);
+}
+
+// Get OS Tick count value.
+__WEAK uint32_t OS_Tick_GetCount (void) {
+  uint32_t load = SysTick->LOAD;
+  return  (load - SysTick->VAL);
+}
+
+// Get OS Tick overflow status.
+__WEAK uint32_t OS_Tick_GetOverflow (void) {
+  return ((SCB->ICSR & SCB_ICSR_PENDSTSET_Msk) >> SCB_ICSR_PENDSTSET_Pos);
+}
+
+#endif  // SysTick

--- a/src/app/stm32h745i/Drivers/CMSIS/RTOS2/Source/os_tick_gtim._c
+++ b/src/app/stm32h745i/Drivers/CMSIS/RTOS2/Source/os_tick_gtim._c
@@ -1,0 +1,187 @@
+/**************************************************************************//**
+ * @file     os_tick_gtim.c
+ * @brief    CMSIS OS Tick implementation for Generic Timer
+ * @version  V1.0.1
+ * @date     24. November 2017
+ ******************************************************************************/
+/*
+ * Copyright (c) 2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "os_tick.h"
+#include "irq_ctrl.h"
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+#ifndef GTIM_IRQ_PRIORITY
+#define GTIM_IRQ_PRIORITY           0xFFU
+#endif
+
+#ifndef GTIM_IRQ_NUM
+#define GTIM_IRQ_NUM                SecurePhyTimer_IRQn
+#endif
+
+// Timer interrupt pending flag
+static uint8_t GTIM_PendIRQ;
+
+// Timer tick frequency
+static uint32_t GTIM_Clock;
+
+// Timer load value
+static uint32_t GTIM_Load;
+
+// Setup OS Tick.
+int32_t OS_Tick_Setup (uint32_t freq, IRQHandler_t handler) {
+  uint32_t prio, bits;
+
+  if (freq == 0U) {
+    return (-1);
+  }
+
+  GTIM_PendIRQ = 0U;
+
+  // Get timer clock
+#ifdef SCTR_BASE
+  GTIM_Clock = *(uint32_t*)(SCTR_BASE+0x20);
+#else
+  // FVP REFCLK CNTControl 100MHz
+  GTIM_Clock = 100000000UL;
+#endif
+
+  PL1_SetCounterFrequency(GTIM_Clock);
+
+  // Calculate load value
+  GTIM_Load = (GTIM_Clock / freq) - 1U;
+
+  // Disable Generic Timer and set load value
+  PL1_SetControl(0U);
+  PL1_SetLoadValue(GTIM_Load);
+
+  // Disable corresponding IRQ
+  IRQ_Disable(GTIM_IRQ_NUM);
+  IRQ_ClearPending(GTIM_IRQ_NUM);
+
+  // Determine number of implemented priority bits
+  IRQ_SetPriority(GTIM_IRQ_NUM, 0xFFU);
+
+  prio = IRQ_GetPriority(GTIM_IRQ_NUM);
+
+  // At least bits [7:4] must be implemented
+  if ((prio & 0xF0U) == 0U) {
+    return (-1);
+  }
+
+  for (bits = 0; bits < 4; bits++) {
+    if ((prio & 0x01) != 0) {
+      break;
+    }
+    prio >>= 1;
+  }
+  
+  // Adjust configured priority to the number of implemented priority bits
+  prio = (GTIM_IRQ_PRIORITY << bits) & 0xFFUL;
+
+  // Set Private Timer interrupt priority
+  IRQ_SetPriority(GTIM_IRQ_NUM, prio-1U);
+
+  // Set edge-triggered IRQ
+  IRQ_SetMode(GTIM_IRQ_NUM, IRQ_MODE_TRIG_EDGE);
+
+  // Register tick interrupt handler function
+  IRQ_SetHandler(GTIM_IRQ_NUM, handler);
+
+  // Enable corresponding interrupt
+  IRQ_Enable(GTIM_IRQ_NUM);
+
+  // Enable system counter and timer control
+#ifdef SCTR_BASE
+  *(uint32_t*)SCTR_BASE |= 3U;
+#endif
+
+  // Enable timer control
+  PL1_SetControl(1U);
+
+  return (0);
+}
+
+/// Enable OS Tick.
+void OS_Tick_Enable (void) {
+  uint32_t ctrl;
+
+  // Set pending interrupt if flag set
+  if (GTIM_PendIRQ != 0U) {
+    GTIM_PendIRQ = 0U;
+    IRQ_SetPending (GTIM_IRQ_NUM);
+  }
+
+  // Start the Private Timer
+  ctrl = PL1_GetControl();
+  // Set bit: Timer enable
+  ctrl |= 1U;
+  PL1_SetControl(ctrl);
+}
+
+/// Disable OS Tick.
+void OS_Tick_Disable (void) {
+  uint32_t ctrl;
+
+  // Stop the Private Timer
+  ctrl = PL1_GetControl();
+  // Clear bit: Timer enable
+  ctrl &= ~1U;
+  PL1_SetControl(ctrl);
+
+  // Remember pending interrupt flag
+  if (IRQ_GetPending(GTIM_IRQ_NUM) != 0) {
+    IRQ_ClearPending(GTIM_IRQ_NUM);
+    GTIM_PendIRQ = 1U;
+  }
+}
+
+// Acknowledge OS Tick IRQ.
+void OS_Tick_AcknowledgeIRQ (void) {
+  IRQ_ClearPending (GTIM_IRQ_NUM);
+  PL1_SetLoadValue(GTIM_Load);
+}
+
+// Get OS Tick IRQ number.
+int32_t  OS_Tick_GetIRQn (void) {
+  return (GTIM_IRQ_NUM);
+}
+
+// Get OS Tick clock.
+uint32_t OS_Tick_GetClock (void) {
+  return (GTIM_Clock);
+}
+
+// Get OS Tick interval.
+uint32_t OS_Tick_GetInterval (void) {
+  return (GTIM_Load + 1U);
+}
+
+// Get OS Tick count value.
+uint32_t OS_Tick_GetCount (void) {
+  return (GTIM_Load - PL1_GetCurrentValue());
+}
+
+// Get OS Tick overflow status.
+uint32_t OS_Tick_GetOverflow (void) {
+  CNTP_CTL_Type cntp_ctl;
+  cntp_ctl.w = PL1_GetControl();
+  return (cntp_ctl.b.ISTATUS);
+}

--- a/src/app/stm32h745i/Drivers/CMSIS/RTOS2/Source/os_tick_ptim.c
+++ b/src/app/stm32h745i/Drivers/CMSIS/RTOS2/Source/os_tick_ptim.c
@@ -1,0 +1,165 @@
+/**************************************************************************//**
+ * @file     os_tick_ptim.c
+ * @brief    CMSIS OS Tick implementation for Private Timer
+ * @version  V1.0.2
+ * @date     02. March 2018
+ ******************************************************************************/
+/*
+ * Copyright (c) 2017-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RTE_Components.h"
+#include CMSIS_device_header
+
+#if defined(PTIM)
+
+#include "os_tick.h"
+#include "irq_ctrl.h"
+
+#ifndef PTIM_IRQ_PRIORITY
+#define PTIM_IRQ_PRIORITY           0xFFU
+#endif
+
+static uint8_t PTIM_PendIRQ;        // Timer interrupt pending flag
+
+// Setup OS Tick.
+int32_t OS_Tick_Setup (uint32_t freq, IRQHandler_t handler) {
+  uint32_t load;
+  uint32_t prio;
+  uint32_t bits;
+
+  if (freq == 0U) {
+    return (-1);
+  }
+
+  PTIM_PendIRQ = 0U;
+
+  // Private Timer runs with the system frequency
+  load = (SystemCoreClock / freq) - 1U;
+
+  // Disable Private Timer and set load value
+  PTIM_SetControl   (0U);
+  PTIM_SetLoadValue (load);
+
+  // Disable corresponding IRQ
+  IRQ_Disable     (PrivTimer_IRQn);
+  IRQ_ClearPending(PrivTimer_IRQn);
+
+  // Determine number of implemented priority bits
+  IRQ_SetPriority (PrivTimer_IRQn, 0xFFU);
+
+  prio = IRQ_GetPriority (PrivTimer_IRQn);
+
+  // At least bits [7:4] must be implemented
+  if ((prio & 0xF0U) == 0U) {
+    return (-1);
+  }
+
+  for (bits = 0; bits < 4; bits++) {
+    if ((prio & 0x01) != 0) {
+      break;
+    }
+    prio >>= 1;
+  }
+
+  // Adjust configured priority to the number of implemented priority bits
+  prio = (PTIM_IRQ_PRIORITY << bits) & 0xFFUL;
+
+  // Set Private Timer interrupt priority
+  IRQ_SetPriority(PrivTimer_IRQn, prio-1U);
+
+  // Set edge-triggered IRQ
+  IRQ_SetMode(PrivTimer_IRQn, IRQ_MODE_TRIG_EDGE);
+
+  // Register tick interrupt handler function
+  IRQ_SetHandler(PrivTimer_IRQn, handler);
+
+  // Enable corresponding interrupt
+  IRQ_Enable (PrivTimer_IRQn);
+
+  // Set bits: IRQ enable and Auto reload
+  PTIM_SetControl (0x06U);
+
+  return (0);
+}
+
+/// Enable OS Tick.
+void OS_Tick_Enable (void) {
+  uint32_t ctrl;
+
+  // Set pending interrupt if flag set
+  if (PTIM_PendIRQ != 0U) {
+    PTIM_PendIRQ = 0U;
+    IRQ_SetPending (PrivTimer_IRQn);
+  }
+
+  // Start the Private Timer
+  ctrl  = PTIM_GetControl();
+  // Set bit: Timer enable
+  ctrl |= 1U;
+  PTIM_SetControl (ctrl);
+}
+
+/// Disable OS Tick.
+void OS_Tick_Disable (void) {
+  uint32_t ctrl;
+
+  // Stop the Private Timer
+  ctrl  = PTIM_GetControl();
+  // Clear bit: Timer enable
+  ctrl &= ~1U;
+  PTIM_SetControl (ctrl);
+
+  // Remember pending interrupt flag
+  if (IRQ_GetPending(PrivTimer_IRQn) != 0) {
+    IRQ_ClearPending (PrivTimer_IRQn);
+    PTIM_PendIRQ = 1U;
+  }
+}
+
+// Acknowledge OS Tick IRQ.
+void OS_Tick_AcknowledgeIRQ (void) {
+  PTIM_ClearEventFlag();
+}
+
+// Get OS Tick IRQ number.
+int32_t  OS_Tick_GetIRQn (void) {
+  return (PrivTimer_IRQn);
+}
+
+// Get OS Tick clock.
+uint32_t OS_Tick_GetClock (void) {
+  return (SystemCoreClock);
+}
+
+// Get OS Tick interval.
+uint32_t OS_Tick_GetInterval (void) {
+  return (PTIM_GetLoadValue() + 1U);
+}
+
+// Get OS Tick count value.
+uint32_t OS_Tick_GetCount (void) {
+  uint32_t load = PTIM_GetLoadValue();
+  return  (load - PTIM_GetCurrentValue());
+}
+
+// Get OS Tick overflow status.
+uint32_t OS_Tick_GetOverflow (void) {
+  return (PTIM->ISR & 1);
+}
+
+#endif  // PTIM

--- a/src/app/stm32h745i/Drivers/CMSIS/RTOS2/Template/cmsis_os.h
+++ b/src/app/stm32h745i/Drivers/CMSIS/RTOS2/Template/cmsis_os.h
@@ -1,0 +1,922 @@
+/*
+ * Copyright (c) 2013-2018 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        18. June 2018
+ * $Revision:    V2.1.3
+ *
+ * Project:      CMSIS-RTOS API
+ * Title:        cmsis_os.h template header file
+ *
+ * Version 0.02
+ *    Initial Proposal Phase
+ * Version 0.03
+ *    osKernelStart added, optional feature: main started as thread
+ *    osSemaphores have standard behavior
+ *    osTimerCreate does not start the timer, added osTimerStart
+ *    osThreadPass is renamed to osThreadYield
+ * Version 1.01
+ *    Support for C++ interface
+ *     - const attribute removed from the osXxxxDef_t typedefs
+ *     - const attribute added to the osXxxxDef macros
+ *    Added: osTimerDelete, osMutexDelete, osSemaphoreDelete
+ *    Added: osKernelInitialize
+ * Version 1.02
+ *    Control functions for short timeouts in microsecond resolution:
+ *    Added: osKernelSysTick, osKernelSysTickFrequency, osKernelSysTickMicroSec
+ *    Removed: osSignalGet 
+ * Version 2.0.0
+ *    OS objects creation without macros (dynamic creation and resource allocation):
+ *     - added: osXxxxNew functions which replace osXxxxCreate
+ *     - added: osXxxxAttr_t structures
+ *     - deprecated: osXxxxCreate functions, osXxxxDef_t structures
+ *     - deprecated: osXxxxDef and osXxxx macros
+ *    osStatus codes simplified and renamed to osStatus_t
+ *    osEvent return structure deprecated
+ *    Kernel:
+ *     - added: osKernelInfo_t and osKernelGetInfo
+ *     - added: osKernelState_t and osKernelGetState (replaces osKernelRunning)
+ *     - added: osKernelLock, osKernelUnlock
+ *     - added: osKernelSuspend, osKernelResume
+ *     - added: osKernelGetTickCount, osKernelGetTickFreq
+ *     - renamed osKernelSysTick to osKernelGetSysTimerCount
+ *     - replaced osKernelSysTickFrequency with osKernelGetSysTimerFreq
+ *     - deprecated osKernelSysTickMicroSec
+ *    Thread:
+ *     - extended number of thread priorities
+ *     - renamed osPrioriry to osPrioriry_t
+ *     - replaced osThreadCreate with osThreadNew
+ *     - added: osThreadGetName
+ *     - added: osThreadState_t and osThreadGetState
+ *     - added: osThreadGetStackSize, osThreadGetStackSpace
+ *     - added: osThreadSuspend, osThreadResume
+ *     - added: osThreadJoin, osThreadDetach, osThreadExit
+ *     - added: osThreadGetCount, osThreadEnumerate
+ *     - added: Thread Flags (moved from Signals) 
+ *    Signals:
+ *     - renamed osSignals to osThreadFlags (moved to Thread Flags)
+ *     - changed return value of Set/Clear/Wait functions
+ *     - Clear function limited to current running thread
+ *     - extended Wait function (options)
+ *     - added: osThreadFlagsGet
+ *    Event Flags:
+ *     - added new independent object for handling Event Flags
+ *    Delay and Wait functions:
+ *     - added: osDelayUntil
+ *     - deprecated: osWait
+ *    Timer:
+ *     - replaced osTimerCreate with osTimerNew
+ *     - added: osTimerGetName, osTimerIsRunning
+ *    Mutex:
+ *     - extended: attributes (Recursive, Priority Inherit, Robust)
+ *     - replaced osMutexCreate with osMutexNew
+ *     - renamed osMutexWait to osMutexAcquire
+ *     - added: osMutexGetName, osMutexGetOwner
+ *    Semaphore:
+ *     - extended: maximum and initial token count
+ *     - replaced osSemaphoreCreate with osSemaphoreNew
+ *     - renamed osSemaphoreWait to osSemaphoreAcquire (changed return value)
+ *     - added: osSemaphoreGetName, osSemaphoreGetCount
+ *    Memory Pool:
+ *     - using osMemoryPool prefix instead of osPool
+ *     - replaced osPoolCreate with osMemoryPoolNew
+ *     - extended osMemoryPoolAlloc (timeout)
+ *     - added: osMemoryPoolGetName
+ *     - added: osMemoryPoolGetCapacity, osMemoryPoolGetBlockSize
+ *     - added: osMemoryPoolGetCount, osMemoryPoolGetSpace
+ *     - added: osMemoryPoolDelete
+ *     - deprecated: osPoolCAlloc
+ *    Message Queue:
+ *     - extended: fixed size message instead of a single 32-bit value
+ *     - using osMessageQueue prefix instead of osMessage
+ *     - replaced osMessageCreate with osMessageQueueNew
+ *     - updated: osMessageQueuePut, osMessageQueueGet
+ *     - added: osMessageQueueGetName
+ *     - added: osMessageQueueGetCapacity, osMessageQueueGetMsgSize
+ *     - added: osMessageQueueGetCount, osMessageQueueGetSpace
+ *     - added: osMessageQueueReset, osMessageQueueDelete
+ *    Mail Queue: 
+ *     - deprecated (superseded by extended Message Queue functionality)
+ * Version 2.1.0
+ *    Support for critical and uncritical sections (nesting safe):
+ *    - updated: osKernelLock, osKernelUnlock
+ *    - added: osKernelRestoreLock
+ *    Updated Thread and Event Flags:
+ *    - changed flags parameter and return type from int32_t to uint32_t
+ * Version 2.1.1
+ *    Additional functions allowed to be called from Interrupt Service Routines:
+ *    - osKernelGetTickCount, osKernelGetTickFreq
+ *    Changed Kernel Tick type to uint32_t:
+ *    - updated: osKernelGetTickCount, osDelayUntil
+ * Version 2.1.2
+ *    Additional functions allowed to be called from Interrupt Service Routines:
+ *    - osKernelGetInfo, osKernelGetState
+ * Version 2.1.3
+ *    Additional functions allowed to be called from Interrupt Service Routines:
+ *    - osThreadGetId
+ *---------------------------------------------------------------------------*/
+ 
+#ifndef CMSIS_OS_H_
+#define CMSIS_OS_H_
+ 
+/// \b osCMSIS identifies the CMSIS-RTOS API version.
+#define osCMSIS             0x20001U    ///< API version (main[31:16].sub[15:0])
+ 
+/// \note CAN BE CHANGED: \b osCMSIS_KERNEL identifies the underlying RTOS kernel and version number.
+#define osCMSIS_KERNEL      0x10000U    ///< RTOS identification and version (main[31:16].sub[15:0])
+ 
+/// \note CAN BE CHANGED: \b osKernelSystemId identifies the underlying RTOS kernel.
+#define osKernelSystemId "KERNEL V1.0"  ///< RTOS identification string
+ 
+/// \note CAN BE CHANGED: \b osFeature_xxx identifies RTOS features.
+#define osFeature_MainThread  0         ///< main thread      1=main can be thread, 0=not available
+#define osFeature_Signals     16U       ///< maximum number of Signal Flags available per thread
+#define osFeature_Semaphore   65535U    ///< maximum count for \ref osSemaphoreCreate function
+#define osFeature_Wait        0         ///< osWait function: 1=available, 0=not available
+#define osFeature_SysTick     1         ///< osKernelSysTick functions: 1=available, 0=not available
+#define osFeature_Pool        1         ///< Memory Pools:    1=available, 0=not available
+#define osFeature_MessageQ    1         ///< Message Queues:  1=available, 0=not available
+#define osFeature_MailQ       1         ///< Mail Queues:     1=available, 0=not available
+ 
+#if (osCMSIS >= 0x20000U)
+#include "cmsis_os2.h"
+#else
+#include <stdint.h>
+#include <stddef.h>
+#endif
+ 
+#ifdef  __cplusplus
+extern "C"
+{
+#endif
+ 
+ 
+// ==== Enumerations, structures, defines ====
+ 
+/// Priority values.
+#if (osCMSIS < 0x20000U)
+typedef enum {
+  osPriorityIdle          = -3,         ///< Priority: idle (lowest)
+  osPriorityLow           = -2,         ///< Priority: low
+  osPriorityBelowNormal   = -1,         ///< Priority: below normal
+  osPriorityNormal        =  0,         ///< Priority: normal (default)
+  osPriorityAboveNormal   = +1,         ///< Priority: above normal
+  osPriorityHigh          = +2,         ///< Priority: high
+  osPriorityRealtime      = +3,         ///< Priority: realtime (highest)
+  osPriorityError         = 0x84,       ///< System cannot determine priority or illegal priority.
+  osPriorityReserved      = 0x7FFFFFFF  ///< Prevents enum down-size compiler optimization.
+} osPriority;
+#else
+#define osPriority osPriority_t
+#endif
+
+/// Entry point of a thread.
+typedef void (*os_pthread) (void const *argument);
+ 
+/// Entry point of a timer call back function.
+typedef void (*os_ptimer) (void const *argument);
+ 
+/// Timer type.
+#if (osCMSIS < 0x20000U)
+typedef enum {
+  osTimerOnce             = 0,          ///< One-shot timer.
+  osTimerPeriodic         = 1           ///< Repeating timer.
+} os_timer_type;
+#else
+#define os_timer_type osTimerType_t
+#endif
+ 
+/// Timeout value.
+#define osWaitForever       0xFFFFFFFFU ///< Wait forever timeout value.
+ 
+/// Status code values returned by CMSIS-RTOS functions.
+#if (osCMSIS < 0x20000U)
+typedef enum {
+  osOK                    =    0,       ///< Function completed; no error or event occurred.
+  osEventSignal           = 0x08,       ///< Function completed; signal event occurred.
+  osEventMessage          = 0x10,       ///< Function completed; message event occurred.
+  osEventMail             = 0x20,       ///< Function completed; mail event occurred.
+  osEventTimeout          = 0x40,       ///< Function completed; timeout occurred.
+  osErrorParameter        = 0x80,       ///< Parameter error: a mandatory parameter was missing or specified an incorrect object.
+  osErrorResource         = 0x81,       ///< Resource not available: a specified resource was not available.
+  osErrorTimeoutResource  = 0xC1,       ///< Resource not available within given time: a specified resource was not available within the timeout period.
+  osErrorISR              = 0x82,       ///< Not allowed in ISR context: the function cannot be called from interrupt service routines.
+  osErrorISRRecursive     = 0x83,       ///< Function called multiple times from ISR with same object.
+  osErrorPriority         = 0x84,       ///< System cannot determine priority or thread has illegal priority.
+  osErrorNoMemory         = 0x85,       ///< System is out of memory: it was impossible to allocate or reserve memory for the operation.
+  osErrorValue            = 0x86,       ///< Value of a parameter is out of range.
+  osErrorOS               = 0xFF,       ///< Unspecified RTOS error: run-time error but no other error message fits.
+  osStatusReserved        = 0x7FFFFFFF  ///< Prevents enum down-size compiler optimization.
+} osStatus;
+#else
+typedef int32_t                  osStatus;
+#define osEventSignal           (0x08)
+#define osEventMessage          (0x10)
+#define osEventMail             (0x20)
+#define osEventTimeout          (0x40)
+#define osErrorOS               osError
+#define osErrorTimeoutResource  osErrorTimeout
+#define osErrorISRRecursive     (-126)
+#define osErrorValue            (-127)
+#define osErrorPriority         (-128)
+#endif
+ 
+ 
+// >>> the following data type definitions may be adapted towards a specific RTOS
+ 
+/// Thread ID identifies the thread.
+/// \note CAN BE CHANGED: \b implementation specific in every CMSIS-RTOS.
+#if (osCMSIS < 0x20000U)
+typedef void *osThreadId;
+#else
+#define osThreadId osThreadId_t
+#endif
+ 
+/// Timer ID identifies the timer.
+/// \note CAN BE CHANGED: \b implementation specific in every CMSIS-RTOS.
+#if (osCMSIS < 0x20000U)
+typedef void *osTimerId;
+#else
+#define osTimerId osTimerId_t
+#endif
+ 
+/// Mutex ID identifies the mutex.
+/// \note CAN BE CHANGED: \b implementation specific in every CMSIS-RTOS.
+#if (osCMSIS < 0x20000U)
+typedef void *osMutexId;
+#else
+#define osMutexId osMutexId_t
+#endif
+ 
+/// Semaphore ID identifies the semaphore.
+/// \note CAN BE CHANGED: \b implementation specific in every CMSIS-RTOS.
+#if (osCMSIS < 0x20000U)
+typedef void *osSemaphoreId;
+#else
+#define osSemaphoreId osSemaphoreId_t
+#endif
+ 
+/// Pool ID identifies the memory pool.
+/// \note CAN BE CHANGED: \b implementation specific in every CMSIS-RTOS.
+typedef void *osPoolId;
+ 
+/// Message ID identifies the message queue.
+/// \note CAN BE CHANGED: \b implementation specific in every CMSIS-RTOS.
+typedef void *osMessageQId;
+ 
+/// Mail ID identifies the mail queue.
+/// \note CAN BE CHANGED: \b implementation specific in every CMSIS-RTOS.
+typedef void *osMailQId;
+ 
+ 
+/// Thread Definition structure contains startup information of a thread.
+/// \note CAN BE CHANGED: \b os_thread_def is implementation specific in every CMSIS-RTOS.
+#if (osCMSIS < 0x20000U)
+typedef struct os_thread_def {
+  os_pthread                 pthread;   ///< start address of thread function
+  osPriority               tpriority;   ///< initial thread priority
+  uint32_t                 instances;   ///< maximum number of instances of that thread function
+  uint32_t                 stacksize;   ///< stack size requirements in bytes; 0 is default stack size
+} osThreadDef_t;
+#else
+typedef struct os_thread_def {
+  os_pthread                 pthread;   ///< start address of thread function
+  osThreadAttr_t                attr;   ///< thread attributes
+} osThreadDef_t;
+#endif
+ 
+/// Timer Definition structure contains timer parameters.
+/// \note CAN BE CHANGED: \b os_timer_def is implementation specific in every CMSIS-RTOS.
+#if (osCMSIS < 0x20000U)
+typedef struct os_timer_def {
+  os_ptimer                   ptimer;   ///< start address of a timer function
+} osTimerDef_t;
+#else
+typedef struct os_timer_def {
+  os_ptimer                   ptimer;   ///< start address of a timer function
+  osTimerAttr_t                 attr;   ///< timer attributes
+} osTimerDef_t;
+#endif
+ 
+/// Mutex Definition structure contains setup information for a mutex.
+/// \note CAN BE CHANGED: \b os_mutex_def is implementation specific in every CMSIS-RTOS.
+#if (osCMSIS < 0x20000U)
+typedef struct os_mutex_def {
+  uint32_t                     dummy;   ///< dummy value
+} osMutexDef_t;
+#else
+#define osMutexDef_t osMutexAttr_t
+#endif
+ 
+/// Semaphore Definition structure contains setup information for a semaphore.
+/// \note CAN BE CHANGED: \b os_semaphore_def is implementation specific in every CMSIS-RTOS.
+#if (osCMSIS < 0x20000U)
+typedef struct os_semaphore_def {
+  uint32_t                     dummy;   ///< dummy value
+} osSemaphoreDef_t;
+#else
+#define osSemaphoreDef_t osSemaphoreAttr_t
+#endif
+ 
+/// Definition structure for memory block allocation.
+/// \note CAN BE CHANGED: \b os_pool_def is implementation specific in every CMSIS-RTOS.
+#if (osCMSIS < 0x20000U)
+typedef struct os_pool_def {
+  uint32_t                   pool_sz;   ///< number of items (elements) in the pool
+  uint32_t                   item_sz;   ///< size of an item
+  void                         *pool;   ///< pointer to memory for pool
+} osPoolDef_t;
+#else
+typedef struct os_pool_def {
+  uint32_t                   pool_sz;   ///< number of items (elements) in the pool
+  uint32_t                   item_sz;   ///< size of an item
+  osMemoryPoolAttr_t            attr;   ///< memory pool attributes
+} osPoolDef_t;
+#endif
+ 
+/// Definition structure for message queue.
+/// \note CAN BE CHANGED: \b os_messageQ_def is implementation specific in every CMSIS-RTOS.
+#if (osCMSIS < 0x20000U)
+typedef struct os_messageQ_def {
+  uint32_t                  queue_sz;   ///< number of elements in the queue
+  void                         *pool;   ///< memory array for messages
+} osMessageQDef_t;
+#else
+typedef struct os_messageQ_def {
+  uint32_t                  queue_sz;   ///< number of elements in the queue
+  osMessageQueueAttr_t          attr;   ///< message queue attributes
+} osMessageQDef_t;
+#endif
+ 
+/// Definition structure for mail queue.
+/// \note CAN BE CHANGED: \b os_mailQ_def is implementation specific in every CMSIS-RTOS.
+#if (osCMSIS < 0x20000U)
+typedef struct os_mailQ_def {
+  uint32_t                  queue_sz;   ///< number of elements in the queue
+  uint32_t                   item_sz;   ///< size of an item
+  void                         *pool;   ///< memory array for mail
+} osMailQDef_t;
+#else
+typedef struct os_mailQ_def {
+  uint32_t                  queue_sz;   ///< number of elements in the queue
+  uint32_t                   item_sz;   ///< size of an item
+  void                         *mail;   ///< pointer to mail
+  osMemoryPoolAttr_t         mp_attr;   ///< memory pool attributes
+  osMessageQueueAttr_t       mq_attr;   ///< message queue attributes
+} osMailQDef_t;
+#endif
+ 
+ 
+/// Event structure contains detailed information about an event.
+typedef struct {
+  osStatus                    status;   ///< status code: event or error information
+  union {
+    uint32_t                       v;   ///< message as 32-bit value
+    void                          *p;   ///< message or mail as void pointer
+    int32_t                  signals;   ///< signal flags
+  } value;                              ///< event value
+  union {
+    osMailQId                mail_id;   ///< mail id obtained by \ref osMailCreate
+    osMessageQId          message_id;   ///< message id obtained by \ref osMessageCreate
+  } def;                                ///< event definition
+} osEvent;
+ 
+ 
+//  ==== Kernel Management Functions ====
+ 
+/// Initialize the RTOS Kernel for creating objects.
+/// \return status code that indicates the execution status of the function.
+#if (osCMSIS < 0x20000U)
+osStatus osKernelInitialize (void);
+#endif
+ 
+/// Start the RTOS Kernel scheduler.
+/// \return status code that indicates the execution status of the function.
+#if (osCMSIS < 0x20000U)
+osStatus osKernelStart (void);
+#endif
+ 
+/// Check if the RTOS kernel is already started.
+/// \return 0 RTOS is not started, 1 RTOS is started.
+#if (osCMSIS < 0x20000U)
+int32_t osKernelRunning(void);
+#endif
+ 
+#if (defined(osFeature_SysTick) && (osFeature_SysTick != 0))  // System Timer available
+ 
+/// Get the RTOS kernel system timer counter.
+/// \return RTOS kernel system timer as 32-bit value 
+#if (osCMSIS < 0x20000U)
+uint32_t osKernelSysTick (void);
+#else
+#define  osKernelSysTick osKernelGetSysTimerCount
+#endif
+ 
+/// The RTOS kernel system timer frequency in Hz.
+/// \note Reflects the system timer setting and is typically defined in a configuration file.
+#if (osCMSIS < 0x20000U)
+#define osKernelSysTickFrequency 100000000
+#endif
+ 
+/// Convert a microseconds value to a RTOS kernel system timer value.
+/// \param         microsec     time value in microseconds.
+/// \return time value normalized to the \ref osKernelSysTickFrequency
+#if (osCMSIS < 0x20000U)
+#define osKernelSysTickMicroSec(microsec) (((uint64_t)microsec * (osKernelSysTickFrequency)) / 1000000)
+#else
+#define osKernelSysTickMicroSec(microsec) (((uint64_t)microsec *  osKernelGetSysTimerFreq()) / 1000000)
+#endif
+ 
+#endif  // System Timer available
+ 
+ 
+//  ==== Thread Management Functions ====
+ 
+/// Create a Thread Definition with function, priority, and stack requirements.
+/// \param         name          name of the thread function.
+/// \param         priority      initial priority of the thread function.
+/// \param         instances     number of possible thread instances.
+/// \param         stacksz       stack size (in bytes) requirements for the thread function.
+/// \note CAN BE CHANGED: The parameters to \b osThreadDef shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
+#if defined (osObjectsExternal)  // object is external
+#define osThreadDef(name, priority, instances, stacksz) \
+extern const osThreadDef_t os_thread_def_##name
+#else                            // define the object
+#if (osCMSIS < 0x20000U)
+#define osThreadDef(name, priority, instances, stacksz) \
+const osThreadDef_t os_thread_def_##name = \
+{ (name), (priority), (instances), (stacksz) }
+#else
+#define osThreadDef(name, priority, instances, stacksz) \
+const osThreadDef_t os_thread_def_##name = \
+{ (name), \
+  { NULL, osThreadDetached, NULL, 0U, NULL, 8*((stacksz+7)/8), (priority), 0U, 0U } }
+#endif
+#endif
+ 
+/// Access a Thread definition.
+/// \param         name          name of the thread definition object.
+/// \note CAN BE CHANGED: The parameter to \b osThread shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
+#define osThread(name) \
+&os_thread_def_##name
+ 
+/// Create a thread and add it to Active Threads and set it to state READY.
+/// \param[in]     thread_def    thread definition referenced with \ref osThread.
+/// \param[in]     argument      pointer that is passed to the thread function as start argument.
+/// \return thread ID for reference by other functions or NULL in case of error.
+osThreadId osThreadCreate (const osThreadDef_t *thread_def, void *argument);
+ 
+/// Return the thread ID of the current running thread.
+/// \return thread ID for reference by other functions or NULL in case of error.
+#if (osCMSIS < 0x20000U)
+osThreadId osThreadGetId (void);
+#endif
+ 
+/// Change priority of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadCreate or \ref osThreadGetId.
+/// \param[in]     priority      new priority value for the thread function.
+/// \return status code that indicates the execution status of the function.
+#if (osCMSIS < 0x20000U)
+osStatus osThreadSetPriority (osThreadId thread_id, osPriority priority);
+#endif
+ 
+/// Get current priority of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadCreate or \ref osThreadGetId.
+/// \return current priority value of the specified thread.
+#if (osCMSIS < 0x20000U)
+osPriority osThreadGetPriority (osThreadId thread_id);
+#endif
+ 
+/// Pass control to next thread that is in state \b READY.
+/// \return status code that indicates the execution status of the function.
+#if (osCMSIS < 0x20000U)
+osStatus osThreadYield (void);
+#endif
+ 
+/// Terminate execution of a thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadCreate or \ref osThreadGetId.
+/// \return status code that indicates the execution status of the function.
+#if (osCMSIS < 0x20000U)
+osStatus osThreadTerminate (osThreadId thread_id);
+#endif
+ 
+ 
+//  ==== Signal Management ====
+ 
+/// Set the specified Signal Flags of an active thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadCreate or \ref osThreadGetId.
+/// \param[in]     signals       specifies the signal flags of the thread that should be set.
+/// \return previous signal flags of the specified thread or 0x80000000 in case of incorrect parameters.
+int32_t osSignalSet (osThreadId thread_id, int32_t signals);
+ 
+/// Clear the specified Signal Flags of an active thread.
+/// \param[in]     thread_id     thread ID obtained by \ref osThreadCreate or \ref osThreadGetId.
+/// \param[in]     signals       specifies the signal flags of the thread that shall be cleared.
+/// \return previous signal flags of the specified thread or 0x80000000 in case of incorrect parameters or call from ISR.
+int32_t osSignalClear (osThreadId thread_id, int32_t signals);
+ 
+/// Wait for one or more Signal Flags to become signaled for the current \b RUNNING thread.
+/// \param[in]     signals       wait until all specified signal flags set or 0 for any single signal flag.
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return event flag information or error code.
+osEvent osSignalWait (int32_t signals, uint32_t millisec);
+ 
+ 
+//  ==== Generic Wait Functions ====
+ 
+/// Wait for Timeout (Time Delay).
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue "time delay" value
+/// \return status code that indicates the execution status of the function.
+#if (osCMSIS < 0x20000U)
+osStatus osDelay (uint32_t millisec);
+#endif
+ 
+#if (defined (osFeature_Wait) && (osFeature_Wait != 0))  // Generic Wait available
+ 
+/// Wait for Signal, Message, Mail, or Timeout.
+/// \param[in] millisec          \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out
+/// \return event that contains signal, message, or mail information or error code.
+osEvent osWait (uint32_t millisec);
+ 
+#endif  // Generic Wait available
+ 
+ 
+//  ==== Timer Management Functions ====
+ 
+/// Define a Timer object.
+/// \param         name          name of the timer object.
+/// \param         function      name of the timer call back function.
+/// \note CAN BE CHANGED: The parameter to \b osTimerDef shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
+#if defined (osObjectsExternal)  // object is external
+#define osTimerDef(name, function) \
+extern const osTimerDef_t os_timer_def_##name
+#else                            // define the object
+#if (osCMSIS < 0x20000U)
+#define osTimerDef(name, function) \
+const osTimerDef_t os_timer_def_##name = { (function) }
+#else
+#define osTimerDef(name, function) \
+const osTimerDef_t os_timer_def_##name = \
+{ (function), { NULL, 0U, NULL, 0U } }
+#endif
+#endif
+ 
+/// Access a Timer definition.
+/// \param         name          name of the timer object.
+/// \note CAN BE CHANGED: The parameter to \b osTimer shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
+#define osTimer(name) \
+&os_timer_def_##name
+ 
+/// Create and Initialize a timer.
+/// \param[in]     timer_def     timer object referenced with \ref osTimer.
+/// \param[in]     type          osTimerOnce for one-shot or osTimerPeriodic for periodic behavior.
+/// \param[in]     argument      argument to the timer call back function.
+/// \return timer ID for reference by other functions or NULL in case of error.
+osTimerId osTimerCreate (const osTimerDef_t *timer_def, os_timer_type type, void *argument);
+ 
+/// Start or restart a timer.
+/// \param[in]     timer_id      timer ID obtained by \ref osTimerCreate.
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue "time delay" value of the timer.
+/// \return status code that indicates the execution status of the function.
+#if (osCMSIS < 0x20000U)
+osStatus osTimerStart (osTimerId timer_id, uint32_t millisec);
+#endif
+ 
+/// Stop a timer.
+/// \param[in]     timer_id      timer ID obtained by \ref osTimerCreate.
+/// \return status code that indicates the execution status of the function.
+#if (osCMSIS < 0x20000U)
+osStatus osTimerStop (osTimerId timer_id);
+#endif
+ 
+/// Delete a timer.
+/// \param[in]     timer_id      timer ID obtained by \ref osTimerCreate.
+/// \return status code that indicates the execution status of the function.
+#if (osCMSIS < 0x20000U)
+osStatus osTimerDelete (osTimerId timer_id);
+#endif
+ 
+ 
+//  ==== Mutex Management Functions ====
+ 
+/// Define a Mutex.
+/// \param         name          name of the mutex object.
+/// \note CAN BE CHANGED: The parameter to \b osMutexDef shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
+#if defined (osObjectsExternal)  // object is external
+#define osMutexDef(name) \
+extern const osMutexDef_t os_mutex_def_##name
+#else                            // define the object
+#if (osCMSIS < 0x20000U)
+#define osMutexDef(name) \
+const osMutexDef_t os_mutex_def_##name = { 0 }
+#else
+#define osMutexDef(name) \
+const osMutexDef_t os_mutex_def_##name = \
+{ NULL, osMutexRecursive | osMutexPrioInherit | osMutexRobust, NULL, 0U }
+#endif
+#endif
+ 
+/// Access a Mutex definition.
+/// \param         name          name of the mutex object.
+/// \note CAN BE CHANGED: The parameter to \b osMutex shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
+#define osMutex(name) \
+&os_mutex_def_##name
+ 
+/// Create and Initialize a Mutex object.
+/// \param[in]     mutex_def     mutex definition referenced with \ref osMutex.
+/// \return mutex ID for reference by other functions or NULL in case of error.
+osMutexId osMutexCreate (const osMutexDef_t *mutex_def);
+ 
+/// Wait until a Mutex becomes available.
+/// \param[in]     mutex_id      mutex ID obtained by \ref osMutexCreate.
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return status code that indicates the execution status of the function.
+#if (osCMSIS < 0x20000U)
+osStatus osMutexWait (osMutexId mutex_id, uint32_t millisec);
+#else
+#define  osMutexWait osMutexAcquire
+#endif
+ 
+/// Release a Mutex that was obtained by \ref osMutexWait.
+/// \param[in]     mutex_id      mutex ID obtained by \ref osMutexCreate.
+/// \return status code that indicates the execution status of the function.
+#if (osCMSIS < 0x20000U)
+osStatus osMutexRelease (osMutexId mutex_id);
+#endif
+ 
+/// Delete a Mutex object.
+/// \param[in]     mutex_id      mutex ID obtained by \ref osMutexCreate.
+/// \return status code that indicates the execution status of the function.
+#if (osCMSIS < 0x20000U)
+osStatus osMutexDelete (osMutexId mutex_id);
+#endif
+ 
+ 
+//  ==== Semaphore Management Functions ====
+ 
+#if (defined (osFeature_Semaphore) && (osFeature_Semaphore != 0U))  // Semaphore available
+ 
+/// Define a Semaphore object.
+/// \param         name          name of the semaphore object.
+/// \note CAN BE CHANGED: The parameter to \b osSemaphoreDef shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
+#if defined (osObjectsExternal)  // object is external
+#define osSemaphoreDef(name) \
+extern const osSemaphoreDef_t os_semaphore_def_##name
+#else                            // define the object
+#if (osCMSIS < 0x20000U)
+#define osSemaphoreDef(name) \
+const osSemaphoreDef_t os_semaphore_def_##name = { 0 }
+#else
+#define osSemaphoreDef(name) \
+const osSemaphoreDef_t os_semaphore_def_##name = \
+{ NULL, 0U, NULL, 0U }
+#endif
+#endif
+ 
+/// Access a Semaphore definition.
+/// \param         name          name of the semaphore object.
+/// \note CAN BE CHANGED: The parameter to \b osSemaphore shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
+#define osSemaphore(name) \
+&os_semaphore_def_##name
+ 
+/// Create and Initialize a Semaphore object.
+/// \param[in]     semaphore_def semaphore definition referenced with \ref osSemaphore.
+/// \param[in]     count         maximum and initial number of available tokens.
+/// \return semaphore ID for reference by other functions or NULL in case of error.
+osSemaphoreId osSemaphoreCreate (const osSemaphoreDef_t *semaphore_def, int32_t count);
+ 
+/// Wait until a Semaphore token becomes available.
+/// \param[in]     semaphore_id  semaphore object referenced with \ref osSemaphoreCreate.
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return number of available tokens, or -1 in case of incorrect parameters.
+int32_t osSemaphoreWait (osSemaphoreId semaphore_id, uint32_t millisec);
+ 
+/// Release a Semaphore token.
+/// \param[in]     semaphore_id  semaphore object referenced with \ref osSemaphoreCreate.
+/// \return status code that indicates the execution status of the function.
+#if (osCMSIS < 0x20000U)
+osStatus osSemaphoreRelease (osSemaphoreId semaphore_id);
+#endif
+ 
+/// Delete a Semaphore object.
+/// \param[in]     semaphore_id  semaphore object referenced with \ref osSemaphoreCreate.
+/// \return status code that indicates the execution status of the function.
+#if (osCMSIS < 0x20000U)
+osStatus osSemaphoreDelete (osSemaphoreId semaphore_id);
+#endif
+ 
+#endif  // Semaphore available
+ 
+ 
+//  ==== Memory Pool Management Functions ====
+ 
+#if (defined(osFeature_Pool) && (osFeature_Pool != 0))  // Memory Pool available
+ 
+/// \brief Define a Memory Pool.
+/// \param         name          name of the memory pool.
+/// \param         no            maximum number of blocks (objects) in the memory pool.
+/// \param         type          data type of a single block (object).
+/// \note CAN BE CHANGED: The parameter to \b osPoolDef shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
+#if defined (osObjectsExternal)  // object is external
+#define osPoolDef(name, no, type) \
+extern const osPoolDef_t os_pool_def_##name
+#else                            // define the object
+#if (osCMSIS < 0x20000U)
+#define osPoolDef(name, no, type) \
+const osPoolDef_t os_pool_def_##name = \
+{ (no), sizeof(type), NULL }
+#else
+#define osPoolDef(name, no, type) \
+const osPoolDef_t os_pool_def_##name = \
+{ (no), sizeof(type), { NULL, 0U, NULL, 0U, NULL, 0U } }
+#endif
+#endif
+ 
+/// \brief Access a Memory Pool definition.
+/// \param         name          name of the memory pool
+/// \note CAN BE CHANGED: The parameter to \b osPool shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
+#define osPool(name) \
+&os_pool_def_##name
+ 
+/// Create and Initialize a Memory Pool object.
+/// \param[in]     pool_def      memory pool definition referenced with \ref osPool.
+/// \return memory pool ID for reference by other functions or NULL in case of error.
+osPoolId osPoolCreate (const osPoolDef_t *pool_def);
+ 
+/// Allocate a memory block from a Memory Pool.
+/// \param[in]     pool_id       memory pool ID obtain referenced with \ref osPoolCreate.
+/// \return address of the allocated memory block or NULL in case of no memory available.
+void *osPoolAlloc (osPoolId pool_id);
+ 
+/// Allocate a memory block from a Memory Pool and set memory block to zero.
+/// \param[in]     pool_id       memory pool ID obtain referenced with \ref osPoolCreate.
+/// \return address of the allocated memory block or NULL in case of no memory available.
+void *osPoolCAlloc (osPoolId pool_id);
+ 
+/// Return an allocated memory block back to a Memory Pool.
+/// \param[in]     pool_id       memory pool ID obtain referenced with \ref osPoolCreate.
+/// \param[in]     block         address of the allocated memory block to be returned to the memory pool.
+/// \return status code that indicates the execution status of the function.
+osStatus osPoolFree (osPoolId pool_id, void *block);
+ 
+#endif  // Memory Pool available
+ 
+ 
+//  ==== Message Queue Management Functions ====
+ 
+#if (defined(osFeature_MessageQ) && (osFeature_MessageQ != 0))  // Message Queue available
+  
+/// \brief Create a Message Queue Definition.
+/// \param         name          name of the queue.
+/// \param         queue_sz      maximum number of messages in the queue.
+/// \param         type          data type of a single message element (for debugger).
+/// \note CAN BE CHANGED: The parameter to \b osMessageQDef shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
+#if defined (osObjectsExternal)  // object is external
+#define osMessageQDef(name, queue_sz, type) \
+extern const osMessageQDef_t os_messageQ_def_##name
+#else                            // define the object
+#if (osCMSIS < 0x20000U)
+#define osMessageQDef(name, queue_sz, type) \
+const osMessageQDef_t os_messageQ_def_##name = \
+{ (queue_sz), NULL }
+#else
+#define osMessageQDef(name, queue_sz, type) \
+const osMessageQDef_t os_messageQ_def_##name = \
+{ (queue_sz), { NULL, 0U, NULL, 0U, NULL, 0U } }
+#endif
+#endif
+ 
+/// \brief Access a Message Queue Definition.
+/// \param         name          name of the queue
+/// \note CAN BE CHANGED: The parameter to \b osMessageQ shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
+#define osMessageQ(name) \
+&os_messageQ_def_##name
+ 
+/// Create and Initialize a Message Queue object.
+/// \param[in]     queue_def     message queue definition referenced with \ref osMessageQ.
+/// \param[in]     thread_id     thread ID (obtained by \ref osThreadCreate or \ref osThreadGetId) or NULL.
+/// \return message queue ID for reference by other functions or NULL in case of error.
+osMessageQId osMessageCreate (const osMessageQDef_t *queue_def, osThreadId thread_id);
+ 
+/// Put a Message to a Queue.
+/// \param[in]     queue_id      message queue ID obtained with \ref osMessageCreate.
+/// \param[in]     info          message information.
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return status code that indicates the execution status of the function.
+osStatus osMessagePut (osMessageQId queue_id, uint32_t info, uint32_t millisec);
+ 
+/// Get a Message from a Queue or timeout if Queue is empty.
+/// \param[in]     queue_id      message queue ID obtained with \ref osMessageCreate.
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return event information that includes status code.
+osEvent osMessageGet (osMessageQId queue_id, uint32_t millisec);
+ 
+#endif  // Message Queue available
+ 
+ 
+//  ==== Mail Queue Management Functions ====
+ 
+#if (defined(osFeature_MailQ) && (osFeature_MailQ != 0))  // Mail Queue available
+ 
+/// \brief Create a Mail Queue Definition.
+/// \param         name          name of the queue.
+/// \param         queue_sz      maximum number of mails in the queue.
+/// \param         type          data type of a single mail element.
+/// \note CAN BE CHANGED: The parameter to \b osMailQDef shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
+#if defined (osObjectsExternal)  // object is external
+#define osMailQDef(name, queue_sz, type) \
+extern const osMailQDef_t os_mailQ_def_##name
+#else                            // define the object
+#if (osCMSIS < 0x20000U)
+#define osMailQDef(name, queue_sz, type) \
+const osMailQDef_t os_mailQ_def_##name = \
+{ (queue_sz), sizeof(type), NULL }
+#else
+#define osMailQDef(name, queue_sz, type) \
+static void *os_mail_p_##name[2]; \
+const osMailQDef_t os_mailQ_def_##name = \
+{ (queue_sz), sizeof(type), (&os_mail_p_##name), \
+  { NULL, 0U, NULL, 0U, NULL, 0U }, \
+  { NULL, 0U, NULL, 0U, NULL, 0U } }
+#endif
+#endif
+ 
+/// \brief Access a Mail Queue Definition.
+/// \param         name          name of the queue
+/// \note CAN BE CHANGED: The parameter to \b osMailQ shall be consistent but the
+///       macro body is implementation specific in every CMSIS-RTOS.
+#define osMailQ(name) \
+&os_mailQ_def_##name
+ 
+/// Create and Initialize a Mail Queue object.
+/// \param[in]     queue_def     mail queue definition referenced with \ref osMailQ.
+/// \param[in]     thread_id     thread ID (obtained by \ref osThreadCreate or \ref osThreadGetId) or NULL.
+/// \return mail queue ID for reference by other functions or NULL in case of error.
+osMailQId osMailCreate (const osMailQDef_t *queue_def, osThreadId thread_id);
+ 
+/// Allocate a memory block for mail from a mail memory pool.
+/// \param[in]     queue_id      mail queue ID obtained with \ref osMailCreate.
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out
+/// \return pointer to memory block that can be filled with mail or NULL in case of error.
+void *osMailAlloc (osMailQId queue_id, uint32_t millisec);
+ 
+/// Allocate a memory block for mail from a mail memory pool and set memory block to zero.
+/// \param[in]     queue_id      mail queue ID obtained with \ref osMailCreate.
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out
+/// \return pointer to memory block that can be filled with mail or NULL in case of error.
+void *osMailCAlloc (osMailQId queue_id, uint32_t millisec);
+ 
+/// Put a Mail into a Queue.
+/// \param[in]     queue_id      mail queue ID obtained with \ref osMailCreate.
+/// \param[in]     mail          pointer to memory with mail to put into a queue.
+/// \return status code that indicates the execution status of the function.
+osStatus osMailPut (osMailQId queue_id, const void *mail);
+ 
+/// Get a Mail from a Queue or timeout if Queue is empty.
+/// \param[in]     queue_id      mail queue ID obtained with \ref osMailCreate.
+/// \param[in]     millisec      \ref CMSIS_RTOS_TimeOutValue or 0 in case of no time-out.
+/// \return event information that includes status code.
+osEvent osMailGet (osMailQId queue_id, uint32_t millisec);
+ 
+/// Free a memory block by returning it to a mail memory pool.
+/// \param[in]     queue_id      mail queue ID obtained with \ref osMailCreate.
+/// \param[in]     mail          pointer to memory block that was obtained with \ref osMailGet.
+/// \return status code that indicates the execution status of the function.
+osStatus osMailFree (osMailQId queue_id, void *mail);
+ 
+#endif  // Mail Queue available
+ 
+ 
+#ifdef  __cplusplus
+}
+#endif
+ 
+#endif  // CMSIS_OS_H_

--- a/src/app/stm32h745i/Drivers/CMSIS/RTOS2/Template/cmsis_os1.c
+++ b/src/app/stm32h745i/Drivers/CMSIS/RTOS2/Template/cmsis_os1.c
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2013-2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        10. January 2017
+ * $Revision:    V1.2
+ *
+ * Project:      CMSIS-RTOS API V1
+ * Title:        cmsis_os_v1.c V1 module file
+ *---------------------------------------------------------------------------*/
+
+#include <string.h>
+#include "cmsis_os.h"
+
+#if (osCMSIS >= 0x20000U)
+
+
+// Thread
+osThreadId osThreadCreate (const osThreadDef_t *thread_def, void *argument) {
+
+  if (thread_def == NULL) {
+    return (osThreadId)NULL;
+  }
+  return osThreadNew((osThreadFunc_t)thread_def->pthread, argument, &thread_def->attr);
+}
+
+
+// Signals
+
+#define SignalMask ((1U<<osFeature_Signals)-1U)
+
+int32_t osSignalSet (osThreadId thread_id, int32_t signals) {
+  uint32_t flags;
+
+  flags = osThreadFlagsSet(thread_id, (uint32_t)signals);
+  if ((flags & 0x80000000U) != 0U) {
+    return ((int32_t)0x80000000U);
+  }
+  return ((int32_t)(flags & ~((uint32_t)signals)));
+}
+
+int32_t osSignalClear (osThreadId thread_id, int32_t signals) {
+  uint32_t flags;
+
+  if (thread_id != osThreadGetId()) {
+    return ((int32_t)0x80000000U);
+  }
+  flags = osThreadFlagsClear((uint32_t)signals);
+  if ((flags & 0x80000000U) != 0U) {
+    return ((int32_t)0x80000000U);
+  }
+  return ((int32_t)flags);
+}
+
+osEvent osSignalWait (int32_t signals, uint32_t millisec) {
+  osEvent  event;
+  uint32_t flags;
+
+  if (signals != 0) {
+    flags = osThreadFlagsWait((uint32_t)signals, osFlagsWaitAll, millisec);
+  } else {
+    flags = osThreadFlagsWait(SignalMask,        osFlagsWaitAny, millisec);
+  }
+  if ((flags > 0U) && (flags < 0x80000000U)) {
+    event.status = osEventSignal;
+    event.value.signals = (int32_t)flags;
+  } else {
+    switch ((int32_t)flags) {
+      case osErrorResource:
+        event.status = osOK;
+        break;
+      case osErrorTimeout:
+        event.status = osEventTimeout;
+        break;
+      case osErrorParameter:
+        event.status = osErrorValue;
+        break;
+      default:
+        event.status = (osStatus)flags;
+        break;
+    }
+  }
+  return event;
+}
+
+
+// Timer
+osTimerId osTimerCreate (const osTimerDef_t *timer_def, os_timer_type type, void *argument) {
+
+  if (timer_def == NULL) {
+    return (osTimerId)NULL;
+  }
+  return osTimerNew((osTimerFunc_t)timer_def->ptimer, type, argument, &timer_def->attr);
+}
+
+
+// Mutex
+osMutexId osMutexCreate (const osMutexDef_t *mutex_def) {
+
+  if (mutex_def == NULL) {
+    return (osMutexId)NULL;
+  }
+  return osMutexNew(mutex_def);
+}
+
+
+// Semaphore
+
+#if (defined (osFeature_Semaphore) && (osFeature_Semaphore != 0U))
+
+osSemaphoreId osSemaphoreCreate (const osSemaphoreDef_t *semaphore_def, int32_t count) {
+
+  if (semaphore_def == NULL) {
+    return (osSemaphoreId)NULL;
+  }
+  return osSemaphoreNew((uint32_t)count, (uint32_t)count, semaphore_def);
+}
+
+int32_t osSemaphoreWait (osSemaphoreId semaphore_id, uint32_t millisec) {
+  osStatus_t status;
+  uint32_t   count;
+
+  status = osSemaphoreAcquire(semaphore_id, millisec);
+  switch (status) {
+    case osOK:
+      count = osSemaphoreGetCount(semaphore_id);
+      return ((int32_t)count + 1);
+    case osErrorResource:
+    case osErrorTimeout:
+      return 0;
+    default:
+      break;
+  }
+  return -1;
+}
+
+#endif  // Semaphore
+
+
+// Memory Pool
+
+#if (defined(osFeature_Pool) && (osFeature_Pool != 0))
+
+osPoolId osPoolCreate (const osPoolDef_t *pool_def) {
+
+  if (pool_def == NULL) {
+    return (osPoolId)NULL;
+  }
+  return ((osPoolId)(osMemoryPoolNew(pool_def->pool_sz, pool_def->item_sz, &pool_def->attr)));
+}
+
+void *osPoolAlloc (osPoolId pool_id) {
+  return osMemoryPoolAlloc((osMemoryPoolId_t)pool_id, 0U);
+}
+
+void *osPoolCAlloc (osPoolId pool_id) {
+  void    *block;
+  uint32_t block_size;
+
+  block_size = osMemoryPoolGetBlockSize((osMemoryPoolId_t)pool_id);
+  if (block_size == 0U) {
+    return NULL;
+  }
+  block = osMemoryPoolAlloc((osMemoryPoolId_t)pool_id, 0U);
+  if (block != NULL) {
+    memset(block, 0, block_size);
+  }
+  return block;
+}
+
+osStatus osPoolFree (osPoolId pool_id, void *block) {
+  return osMemoryPoolFree((osMemoryPoolId_t)pool_id, block);
+}
+
+#endif  // Memory Pool
+
+
+// Message Queue
+
+#if (defined(osFeature_MessageQ) && (osFeature_MessageQ != 0))
+
+osMessageQId osMessageCreate (const osMessageQDef_t *queue_def, osThreadId thread_id) {
+  (void)thread_id;
+
+  if (queue_def == NULL) {
+    return (osMessageQId)NULL;
+  }
+  return ((osMessageQId)(osMessageQueueNew(queue_def->queue_sz, sizeof(uint32_t), &queue_def->attr)));
+}
+
+osStatus osMessagePut (osMessageQId queue_id, uint32_t info, uint32_t millisec) {
+  return osMessageQueuePut((osMessageQueueId_t)queue_id, &info, 0U, millisec);
+}
+
+osEvent osMessageGet (osMessageQId queue_id, uint32_t millisec) {
+  osStatus_t status;
+  osEvent    event;
+  uint32_t   message;
+
+  status = osMessageQueueGet((osMessageQueueId_t)queue_id, &message, NULL, millisec);
+  switch (status) {
+    case osOK:
+      event.status = osEventMessage;
+      event.value.v = message;
+      break;
+    case osErrorResource:
+      event.status = osOK;
+      break;
+    case osErrorTimeout:
+      event.status = osEventTimeout;
+      break;
+    default:
+      event.status = status;
+      break;
+  }
+  return event;
+}
+
+#endif  // Message Queue
+
+
+// Mail Queue
+
+#if (defined(osFeature_MailQ) && (osFeature_MailQ != 0))
+
+typedef struct os_mail_queue_s {
+  osMemoryPoolId_t   mp_id;
+  osMessageQueueId_t mq_id;
+} os_mail_queue_t;
+
+osMailQId osMailCreate (const osMailQDef_t *queue_def, osThreadId thread_id) {
+  os_mail_queue_t *ptr;
+  (void)thread_id;
+
+  if (queue_def == NULL) {
+    return (osMailQId)NULL;
+  }
+
+  ptr = queue_def->mail;
+  if (ptr == NULL) {
+    return (osMailQId)NULL;
+  }
+
+  ptr->mp_id = osMemoryPoolNew  (queue_def->queue_sz, queue_def->item_sz, &queue_def->mp_attr);
+  ptr->mq_id = osMessageQueueNew(queue_def->queue_sz, sizeof(void *), &queue_def->mq_attr);
+  if ((ptr->mp_id == (osMemoryPoolId_t)NULL) || (ptr->mq_id == (osMessageQueueId_t)NULL)) {
+    if (ptr->mp_id != (osMemoryPoolId_t)NULL) {
+      osMemoryPoolDelete(ptr->mp_id);
+    }
+    if (ptr->mq_id != (osMessageQueueId_t)NULL) {
+      osMessageQueueDelete(ptr->mq_id);
+    }
+    return (osMailQId)NULL;
+  }
+
+  return (osMailQId)ptr;
+}
+
+void *osMailAlloc (osMailQId queue_id, uint32_t millisec) {
+  os_mail_queue_t *ptr = (os_mail_queue_t *)queue_id;
+
+  if (ptr == NULL) {
+    return NULL;
+  }
+  return osMemoryPoolAlloc(ptr->mp_id, millisec);
+}
+
+void *osMailCAlloc (osMailQId queue_id, uint32_t millisec) {
+  os_mail_queue_t *ptr = (os_mail_queue_t *)queue_id;
+  void            *block;
+  uint32_t         block_size;
+
+  if (ptr == NULL) {
+    return NULL;
+  }
+  block_size = osMemoryPoolGetBlockSize(ptr->mp_id);
+  if (block_size == 0U) {
+    return NULL;
+  }
+  block = osMemoryPoolAlloc(ptr->mp_id, millisec);
+  if (block != NULL) {
+    memset(block, 0, block_size);
+  }
+
+  return block;
+
+}
+
+osStatus osMailPut (osMailQId queue_id, const void *mail) {
+  os_mail_queue_t *ptr = (os_mail_queue_t *)queue_id;
+
+  if (ptr == NULL) {
+    return osErrorParameter;
+  }
+  if (mail == NULL) {
+    return osErrorValue;
+  }
+  return osMessageQueuePut(ptr->mq_id, &mail, 0U, 0U);
+}
+
+osEvent osMailGet (osMailQId queue_id, uint32_t millisec) {
+  os_mail_queue_t *ptr = (os_mail_queue_t *)queue_id;
+  osStatus_t       status;
+  osEvent          event;
+  void            *mail;
+
+  if (ptr == NULL) {
+    event.status = osErrorParameter;
+    return event;
+  }
+
+  status = osMessageQueueGet(ptr->mq_id, &mail, NULL, millisec);
+  switch (status) {
+    case osOK:
+      event.status = osEventMail;
+      event.value.p = mail;
+      break;
+    case osErrorResource:
+      event.status = osOK;
+      break;
+    case osErrorTimeout:
+      event.status = osEventTimeout;
+      break;
+    default:
+      event.status = status;
+      break;
+  }
+  return event;
+}
+
+osStatus osMailFree (osMailQId queue_id, void *mail) {
+  os_mail_queue_t *ptr = (os_mail_queue_t *)queue_id;
+
+  if (ptr == NULL) {
+    return osErrorParameter;
+  }
+  if (mail == NULL) {
+    return osErrorValue;
+  }
+  return osMemoryPoolFree(ptr->mp_id, mail);
+}
+
+#endif  // Mail Queue
+
+
+#endif  // osCMSIS

--- a/src/app/stm32h745i/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2/cmsis_os.h
+++ b/src/app/stm32h745i/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2/cmsis_os.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2013-2019 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ----------------------------------------------------------------------
+ *
+ * $Date:        10. January 2017
+ * $Revision:    V2.1.0
+ *
+ * Project:      CMSIS-RTOS API
+ * Title:        cmsis_os.h FreeRTOS header file
+ *---------------------------------------------------------------------------*/
+
+#ifndef CMSIS_OS_H_
+#define CMSIS_OS_H_
+
+#define osCMSIS               0x20001U  ///< API version (main[31:16].sub[15:0])
+
+#include "cmsis_os2.h"
+
+#endif  // CMSIS_OS_H_

--- a/src/app/stm32h745i/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2/cmsis_os2.c
+++ b/src/app/stm32h745i/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2/cmsis_os2.c
@@ -1,0 +1,2957 @@
+/* --------------------------------------------------------------------------
+ * Copyright (c) 2013-2022 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *      Name:    cmsis_os2.c
+ *      Purpose: CMSIS RTOS2 wrapper for FreeRTOS
+ *
+ *---------------------------------------------------------------------------*/
+#include <string.h>
+
+#include "FreeRTOS.h"                   // ARM.FreeRTOS::RTOS:Core
+#include "task.h"                       // ARM.FreeRTOS::RTOS:Core
+#include "event_groups.h"               // ARM.FreeRTOS::RTOS:Event Groups
+#include "semphr.h"                     // ARM.FreeRTOS::RTOS:Core
+#include "timers.h"                     // ARM.FreeRTOS::RTOS:Timers
+
+#include "freertos_mpool.h"             // osMemoryPool definitions
+#include "freertos_os2.h"               // Configuration check and setup
+
+#include "cmsis_os2.h"                  // ::CMSIS:RTOS2
+#include "cmsis_compiler.h"             // Compiler agnostic definitions
+
+/*---------------------------------------------------------------------------*/
+#ifndef __ARM_ARCH_6M__
+  #define __ARM_ARCH_6M__         0
+#endif
+#ifndef __ARM_ARCH_7M__
+  #define __ARM_ARCH_7M__         0
+#endif
+#ifndef __ARM_ARCH_7EM__
+  #define __ARM_ARCH_7EM__        0
+#endif
+#ifndef __ARM_ARCH_8M_MAIN__
+  #define __ARM_ARCH_8M_MAIN__    0
+#endif
+#ifndef __ARM_ARCH_7A__
+  #define __ARM_ARCH_7A__         0
+#endif
+
+#if   ((__ARM_ARCH_7M__      == 1U) || \
+       (__ARM_ARCH_7EM__     == 1U) || \
+       (__ARM_ARCH_8M_MAIN__ == 1U))
+#define IS_IRQ_MASKED()           ((__get_PRIMASK() != 0U) || (__get_BASEPRI() != 0U))
+#elif  (__ARM_ARCH_6M__      == 1U)
+#define IS_IRQ_MASKED()           (__get_PRIMASK() != 0U)
+#elif (__ARM_ARCH_7A__       == 1U)
+/* CPSR mask bits */
+#define CPSR_MASKBIT_I            0x80U
+
+#define IS_IRQ_MASKED()           ((__get_CPSR() & CPSR_MASKBIT_I) != 0U)
+#else
+#define IS_IRQ_MASKED()           (__get_PRIMASK() != 0U)
+#endif
+
+#if    (__ARM_ARCH_7A__      == 1U)
+/* CPSR mode bitmasks */
+#define CPSR_MODE_USER            0x10U
+#define CPSR_MODE_SYSTEM          0x1FU
+
+#define IS_IRQ_MODE()             ((__get_mode() != CPSR_MODE_USER) && (__get_mode() != CPSR_MODE_SYSTEM))
+#else
+#define IS_IRQ_MODE()             (__get_IPSR() != 0U)
+#endif
+
+/* Limits */
+#define MAX_BITS_TASK_NOTIFY      31U
+#define MAX_BITS_EVENT_GROUPS     24U
+
+#define THREAD_FLAGS_INVALID_BITS (~((1UL << MAX_BITS_TASK_NOTIFY)  - 1U))
+#define EVENT_FLAGS_INVALID_BITS  (~((1UL << MAX_BITS_EVENT_GROUPS) - 1U))
+
+/* Kernel version and identification string definition (major.minor.rev: mmnnnrrrr dec) */
+#define KERNEL_VERSION            (((uint32_t)tskKERNEL_VERSION_MAJOR * 10000000UL) | \
+                                   ((uint32_t)tskKERNEL_VERSION_MINOR *    10000UL) | \
+                                   ((uint32_t)tskKERNEL_VERSION_BUILD *        1UL))
+
+#define KERNEL_ID                 ("FreeRTOS " tskKERNEL_VERSION_NUMBER)
+
+/* Timer callback information structure definition */
+typedef struct {
+  osTimerFunc_t func;
+  void         *arg;
+} TimerCallback_t;
+
+/* Kernel initialization state */
+static osKernelState_t KernelState = osKernelInactive;
+
+/* Get OS Tick count value */
+static uint32_t OS_Tick_GetCount (void);
+#if (configUSE_TICKLESS_IDLE == 0)
+/* Get OS Tick overflow status */
+static uint32_t OS_Tick_GetOverflow (void);
+#endif
+/* Get OS Tick interval */
+static uint32_t OS_Tick_GetInterval (void);
+
+/*
+  Heap region definition used by heap_5 variant
+
+  Define configAPPLICATION_ALLOCATED_HEAP as nonzero value in FreeRTOSConfig.h if
+  heap regions are already defined and vPortDefineHeapRegions is called in application.
+
+  Otherwise vPortDefineHeapRegions will be called by osKernelInitialize using
+  definition configHEAP_5_REGIONS as parameter. Overriding configHEAP_5_REGIONS
+  is possible by defining it globally or in FreeRTOSConfig.h.
+*/
+#if defined(USE_FreeRTOS_HEAP_5)
+#if (configAPPLICATION_ALLOCATED_HEAP == 0)
+  /*
+    FreeRTOS heap is not defined by the application.
+    Single region of size configTOTAL_HEAP_SIZE (defined in FreeRTOSConfig.h)
+    is provided by default. Define configHEAP_5_REGIONS to provide custom
+    HeapRegion_t array.
+  */
+  #define HEAP_5_REGION_SETUP   1
+
+  #ifndef configHEAP_5_REGIONS
+    #define configHEAP_5_REGIONS xHeapRegions
+
+    static uint8_t ucHeap[configTOTAL_HEAP_SIZE];
+
+    static HeapRegion_t xHeapRegions[] = {
+      { ucHeap, configTOTAL_HEAP_SIZE },
+      { NULL,   0                     }
+    };
+  #else
+    /* Global definition is provided to override default heap array */
+    extern HeapRegion_t configHEAP_5_REGIONS[];
+  #endif
+#else
+  /*
+    The application already defined the array used for the FreeRTOS heap and
+    called vPortDefineHeapRegions to initialize heap.
+  */
+  #define HEAP_5_REGION_SETUP   0
+#endif /* configAPPLICATION_ALLOCATED_HEAP */
+#endif /* USE_FreeRTOS_HEAP_5 */
+
+#if defined(SysTick)
+#undef SysTick_Handler
+
+/* CMSIS SysTick interrupt handler prototype */
+extern void SysTick_Handler     (void);
+/* FreeRTOS tick timer interrupt handler prototype */
+extern void xPortSysTickHandler (void);
+
+/*
+  SysTick handler implementation that also clears overflow flag.
+*/
+#if (USE_CUSTOM_SYSTICK_HANDLER_IMPLEMENTATION == 0)
+void SysTick_Handler (void) {
+#if (configUSE_TICKLESS_IDLE == 0)
+  /* Clear overflow flag */
+  SysTick->CTRL;
+#endif
+
+  if (xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED) {
+    /* Call tick handler */
+    xPortSysTickHandler();
+  }
+}
+#endif
+#endif /* SysTick */
+
+/*
+  Setup SVC to reset value.
+*/
+__STATIC_INLINE void SVC_Setup (void) {
+#if (__ARM_ARCH_7A__ == 0U)
+  /* Service Call interrupt might be configured before kernel start      */
+  /* and when its priority is lower or equal to BASEPRI, svc instruction */
+  /* causes a Hard Fault.                                                */
+  NVIC_SetPriority (SVCall_IRQn, 0U);
+#endif
+}
+
+/*
+  Function macro used to retrieve semaphore count from ISR
+*/
+#ifndef uxSemaphoreGetCountFromISR
+#define uxSemaphoreGetCountFromISR( xSemaphore ) uxQueueMessagesWaitingFromISR( ( QueueHandle_t ) ( xSemaphore ) )
+#endif
+
+/*
+  Determine if CPU executes from interrupt context or if interrupts are masked.
+*/
+__STATIC_INLINE uint32_t IRQ_Context (void) {
+  uint32_t irq;
+  BaseType_t state;
+
+  irq = 0U;
+
+  if (IS_IRQ_MODE()) {
+    /* Called from interrupt context */
+    irq = 1U;
+  }
+  else {
+    /* Get FreeRTOS scheduler state */
+    state = xTaskGetSchedulerState();
+
+    if (state != taskSCHEDULER_NOT_STARTED) {
+      /* Scheduler was started */
+      if (IS_IRQ_MASKED()) {
+        /* Interrupts are masked */
+        irq = 1U;
+      }
+    }
+  }
+
+  /* Return context, 0: thread context, 1: IRQ context */
+  return (irq);
+}
+
+/* Get OS Tick count value */
+static uint32_t OS_Tick_GetCount (void) {
+#if (__ARM_ARCH_7A__ == 1U)
+  return (__get_CNTFRQ() - PL1_GetCurrentValue());
+#else
+  uint32_t load = SysTick->LOAD;
+  return  (load - SysTick->VAL);
+#endif /* __ARM_ARCH_7A__ */
+}
+
+#if (configUSE_TICKLESS_IDLE == 0)
+/* Get OS Tick overflow status */
+static uint32_t OS_Tick_GetOverflow (void) {
+#if (__ARM_ARCH_7A__ == 1U)
+  CNTP_CTL_Type cntp_ctl;
+  cntp_ctl.w = PL1_GetControl();
+  return (cntp_ctl.b.ISTATUS);
+#else
+  return ((SysTick->CTRL >> 16) & 1U);
+#endif /* __ARM_ARCH_7A__ */
+}
+#endif
+
+/* Get OS Tick interval */
+static uint32_t OS_Tick_GetInterval (void) {
+#if (__ARM_ARCH_7A__ == 1U)
+  return (__get_CNTFRQ() + 1U);
+#else
+  return (SysTick->LOAD + 1U);
+#endif /* __ARM_ARCH_7A__ */
+}
+
+/* ==== Kernel Management Functions ==== */
+
+/*
+  Initialize the RTOS Kernel.
+*/
+osStatus_t osKernelInitialize (void) {
+  osStatus_t stat;
+  BaseType_t state;
+
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else {
+    state = xTaskGetSchedulerState();
+
+    /* Initialize if scheduler not started and not initialized before */
+    if ((state == taskSCHEDULER_NOT_STARTED) && (KernelState == osKernelInactive)) {
+      #if defined(USE_TRACE_EVENT_RECORDER)
+        /* Initialize the trace macro debugging output channel */
+        EvrFreeRTOSSetup(0U);
+      #endif
+      #if defined(USE_FreeRTOS_HEAP_5) && (HEAP_5_REGION_SETUP == 1)
+        /* Initialize the memory regions when using heap_5 variant */
+        vPortDefineHeapRegions (configHEAP_5_REGIONS);
+      #endif
+      KernelState = osKernelReady;
+      stat = osOK;
+    } else {
+      stat = osError;
+    }
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Get RTOS Kernel Information.
+*/
+osStatus_t osKernelGetInfo (osVersion_t *version, char *id_buf, uint32_t id_size) {
+
+  if (version != NULL) {
+    /* Version encoding is major.minor.rev: mmnnnrrrr dec */
+    version->api    = KERNEL_VERSION;
+    version->kernel = KERNEL_VERSION;
+  }
+
+  if ((id_buf != NULL) && (id_size != 0U)) {
+    /* Buffer for retrieving identification string is provided */
+    if (id_size > sizeof(KERNEL_ID)) {
+      id_size = sizeof(KERNEL_ID);
+    }
+    /* Copy kernel identification string into provided buffer */
+    memcpy(id_buf, KERNEL_ID, id_size);
+  }
+
+  /* Return execution status */
+  return (osOK);
+}
+
+/*
+  Get the current RTOS Kernel state.
+*/
+osKernelState_t osKernelGetState (void) {
+  osKernelState_t state;
+
+  switch (xTaskGetSchedulerState()) {
+    case taskSCHEDULER_RUNNING:
+      state = osKernelRunning;
+      break;
+
+    case taskSCHEDULER_SUSPENDED:
+      state = osKernelLocked;
+      break;
+
+    case taskSCHEDULER_NOT_STARTED:
+    default:
+      if (KernelState == osKernelReady) {
+        /* Ready, osKernelInitialize was already called */
+        state = osKernelReady;
+      } else {
+        /* Not initialized */
+        state = osKernelInactive;
+      }
+      break;
+  }
+
+  /* Return current state */
+  return (state);
+}
+
+/*
+  Start the RTOS Kernel scheduler.
+*/
+osStatus_t osKernelStart (void) {
+  osStatus_t stat;
+  BaseType_t state;
+
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else {
+    state = xTaskGetSchedulerState();
+
+    /* Start scheduler if initialized and not started before */
+    if ((state == taskSCHEDULER_NOT_STARTED) && (KernelState == osKernelReady)) {
+      /* Ensure SVC priority is at the reset value */
+      SVC_Setup();
+      /* Change state to ensure correct API flow */
+      KernelState = osKernelRunning;
+      /* Start the kernel scheduler */
+      vTaskStartScheduler();
+      stat = osOK;
+    } else {
+      stat = osError;
+    }
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Lock the RTOS Kernel scheduler.
+*/
+int32_t osKernelLock (void) {
+  int32_t lock;
+
+  if (IRQ_Context() != 0U) {
+    lock = (int32_t)osErrorISR;
+  }
+  else {
+    switch (xTaskGetSchedulerState()) {
+      case taskSCHEDULER_SUSPENDED:
+        lock = 1;
+        break;
+
+      case taskSCHEDULER_RUNNING:
+        vTaskSuspendAll();
+        lock = 0;
+        break;
+
+      case taskSCHEDULER_NOT_STARTED:
+      default:
+        lock = (int32_t)osError;
+        break;
+    }
+  }
+
+  /* Return previous lock state */
+  return (lock);
+}
+
+/*
+  Unlock the RTOS Kernel scheduler.
+*/
+int32_t osKernelUnlock (void) {
+  int32_t lock;
+
+  if (IRQ_Context() != 0U) {
+    lock = (int32_t)osErrorISR;
+  }
+  else {
+    switch (xTaskGetSchedulerState()) {
+      case taskSCHEDULER_SUSPENDED:
+        lock = 1;
+
+        if (xTaskResumeAll() != pdTRUE) {
+          if (xTaskGetSchedulerState() == taskSCHEDULER_SUSPENDED) {
+            lock = (int32_t)osError;
+          }
+        }
+        break;
+
+      case taskSCHEDULER_RUNNING:
+        lock = 0;
+        break;
+
+      case taskSCHEDULER_NOT_STARTED:
+      default:
+        lock = (int32_t)osError;
+        break;
+    }
+  }
+
+  /* Return previous lock state */
+  return (lock);
+}
+
+/*
+  Restore the RTOS Kernel scheduler lock state.
+*/
+int32_t osKernelRestoreLock (int32_t lock) {
+
+  if (IRQ_Context() != 0U) {
+    lock = (int32_t)osErrorISR;
+  }
+  else {
+    switch (xTaskGetSchedulerState()) {
+      case taskSCHEDULER_SUSPENDED:
+      case taskSCHEDULER_RUNNING:
+        if (lock == 1) {
+          vTaskSuspendAll();
+        }
+        else {
+          if (lock != 0) {
+            lock = (int32_t)osError;
+          }
+          else {
+            if (xTaskResumeAll() != pdTRUE) {
+              if (xTaskGetSchedulerState() != taskSCHEDULER_RUNNING) {
+                lock = (int32_t)osError;
+              }
+            }
+          }
+        }
+        break;
+
+      case taskSCHEDULER_NOT_STARTED:
+      default:
+        lock = (int32_t)osError;
+        break;
+    }
+  }
+
+  /* Return new lock state */
+  return (lock);
+}
+
+/*
+  Get the RTOS kernel tick count.
+*/
+uint32_t osKernelGetTickCount (void) {
+  TickType_t ticks;
+
+  if (IRQ_Context() != 0U) {
+    ticks = xTaskGetTickCountFromISR();
+  } else {
+    ticks = xTaskGetTickCount();
+  }
+
+  /* Return kernel tick count */
+  return (ticks);
+}
+
+/*
+  Get the RTOS kernel tick frequency.
+*/
+uint32_t osKernelGetTickFreq (void) {
+  /* Return frequency in hertz */
+  return (configTICK_RATE_HZ);
+}
+
+/*
+  Get the RTOS kernel system timer count.
+*/
+uint32_t osKernelGetSysTimerCount (void) {
+  uint32_t irqmask = IS_IRQ_MASKED();
+  TickType_t ticks;
+  uint32_t val;
+#if (configUSE_TICKLESS_IDLE != 0)
+  uint32_t val0;
+
+  /* Low Power Tickless Idle controls timer overflow flag and therefore      */
+  /* OS_Tick_GetOverflow may be non-functional. As a workaround a reference  */
+  /* time is measured here before disabling interrupts. Timer value overflow */
+  /* is then checked by comparing reference against latest time measurement. */
+  /* Timer count value returned by this method is less accurate but if an    */
+  /* overflow is missed, an invalid timer count would be returned.           */
+  val0 = OS_Tick_GetCount();
+#endif
+
+  __disable_irq();
+
+  ticks = xTaskGetTickCount();
+  val   = OS_Tick_GetCount();
+
+  /* Update tick count and timer value when timer overflows */
+#if (configUSE_TICKLESS_IDLE != 0)
+  if (val < val0) {
+    ticks++;
+  }
+#else
+  if (OS_Tick_GetOverflow() != 0U) {
+    val = OS_Tick_GetCount();
+    ticks++;
+  }
+#endif
+
+  val += ticks * OS_Tick_GetInterval();
+
+  if (irqmask == 0U) {
+    __enable_irq();
+  }
+
+  /* Return system timer count */
+  return (val);
+}
+
+/*
+  Get the RTOS kernel system timer frequency.
+*/
+uint32_t osKernelGetSysTimerFreq (void) {
+  /* Return frequency in hertz */
+  return (configCPU_CLOCK_HZ);
+}
+
+
+/* ==== Thread Management Functions ==== */
+
+/*
+  Create a thread and add it to Active Threads.
+
+  Limitations:
+  - The memory for control block and stack must be provided in the osThreadAttr_t
+    structure in order to allocate object statically.
+  - Attribute osThreadJoinable is not supported, NULL is returned if used.
+*/
+osThreadId_t osThreadNew (osThreadFunc_t func, void *argument, const osThreadAttr_t *attr) {
+  const char *name;
+  uint32_t stack;
+  TaskHandle_t hTask;
+  UBaseType_t prio;
+  int32_t mem;
+
+  hTask = NULL;
+
+  if ((IRQ_Context() == 0U) && (func != NULL)) {
+    stack = configMINIMAL_STACK_SIZE;
+    prio  = (UBaseType_t)osPriorityNormal;
+
+    name = NULL;
+    mem  = -1;
+
+    if (attr != NULL) {
+      if (attr->name != NULL) {
+        name = attr->name;
+      }
+      if (attr->priority != osPriorityNone) {
+        prio = (UBaseType_t)attr->priority;
+      }
+
+      if ((prio < osPriorityIdle) || (prio > osPriorityISR) || ((attr->attr_bits & osThreadJoinable) == osThreadJoinable)) {
+        /* Invalid priority or unsupported osThreadJoinable attribute used */
+        return (NULL);
+      }
+
+      if (attr->stack_size > 0U) {
+        /* In FreeRTOS stack is not in bytes, but in sizeof(StackType_t) which is 4 on ARM ports.       */
+        /* Stack size should be therefore 4 byte aligned in order to avoid division caused side effects */
+        stack = attr->stack_size / sizeof(StackType_t);
+      }
+
+      if ((attr->cb_mem    != NULL) && (attr->cb_size    >= sizeof(StaticTask_t)) &&
+          (attr->stack_mem != NULL) && (attr->stack_size >  0U)) {
+        /* The memory for control block and stack is provided, use static object */
+        mem = 1;
+      }
+      else {
+        if ((attr->cb_mem == NULL) && (attr->cb_size == 0U) && (attr->stack_mem == NULL)) {
+          /* Control block and stack memory will be allocated from the dynamic pool */
+          mem = 0;
+        }
+      }
+    }
+    else {
+      mem = 0;
+    }
+
+    if (mem == 1) {
+      #if (configSUPPORT_STATIC_ALLOCATION == 1)
+        hTask = xTaskCreateStatic ((TaskFunction_t)func, name, stack, argument, prio, (StackType_t  *)attr->stack_mem,
+                                                                                      (StaticTask_t *)attr->cb_mem);
+      #endif
+    }
+    else {
+      if (mem == 0) {
+        #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+          if (xTaskCreate ((TaskFunction_t)func, name, (configSTACK_DEPTH_TYPE)stack, argument, prio, &hTask) != pdPASS) {
+            hTask = NULL;
+          }
+        #endif
+      }
+    }
+  }
+
+  /* Return thread ID */
+  return ((osThreadId_t)hTask);
+}
+
+/*
+  Get name of a thread.
+*/
+const char *osThreadGetName (osThreadId_t thread_id) {
+  TaskHandle_t hTask = (TaskHandle_t)thread_id;
+  const char *name;
+
+  if ((IRQ_Context() != 0U) || (hTask == NULL)) {
+    name = NULL;
+  } else {
+    name = pcTaskGetName (hTask);
+  }
+
+  /* Return name as null-terminated string */
+  return (name);
+}
+
+/*
+  Return the thread ID of the current running thread.
+*/
+osThreadId_t osThreadGetId (void) {
+  osThreadId_t id;
+
+  id = (osThreadId_t)xTaskGetCurrentTaskHandle();
+
+  /* Return thread ID */
+  return (id);
+}
+
+/*
+  Get current thread state of a thread.
+*/
+osThreadState_t osThreadGetState (osThreadId_t thread_id) {
+  TaskHandle_t hTask = (TaskHandle_t)thread_id;
+  osThreadState_t state;
+
+  if ((IRQ_Context() != 0U) || (hTask == NULL)) {
+    state = osThreadError;
+  }
+  else {
+    switch (eTaskGetState (hTask)) {
+      case eRunning:   state = osThreadRunning;    break;
+      case eReady:     state = osThreadReady;      break;
+      case eBlocked:
+      case eSuspended: state = osThreadBlocked;    break;
+      case eDeleted:
+      case eInvalid:
+      default:         state = osThreadError;      break;
+    }
+  }
+
+  /* Return current thread state */
+  return (state);
+}
+
+/*
+  Get available stack space of a thread based on stack watermark recording during execution.
+*/
+uint32_t osThreadGetStackSpace (osThreadId_t thread_id) {
+  TaskHandle_t hTask = (TaskHandle_t)thread_id;
+  uint32_t sz;
+
+  if ((IRQ_Context() != 0U) || (hTask == NULL)) {
+    sz = 0U;
+  } else {
+    sz = (uint32_t)(uxTaskGetStackHighWaterMark(hTask) * sizeof(StackType_t));
+  }
+
+  /* Return remaining stack space in bytes */
+  return (sz);
+}
+
+/*
+  Change priority of a thread.
+*/
+osStatus_t osThreadSetPriority (osThreadId_t thread_id, osPriority_t priority) {
+  TaskHandle_t hTask = (TaskHandle_t)thread_id;
+  osStatus_t stat;
+
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else if ((hTask == NULL) || (priority < osPriorityIdle) || (priority > osPriorityISR)) {
+    stat = osErrorParameter;
+  }
+  else {
+    stat = osOK;
+    vTaskPrioritySet (hTask, (UBaseType_t)priority);
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Get current priority of a thread.
+*/
+osPriority_t osThreadGetPriority (osThreadId_t thread_id) {
+  TaskHandle_t hTask = (TaskHandle_t)thread_id;
+  osPriority_t prio;
+
+  if ((IRQ_Context() != 0U) || (hTask == NULL)) {
+    prio = osPriorityError;
+  } else {
+    prio = (osPriority_t)((int32_t)uxTaskPriorityGet (hTask));
+  }
+
+  /* Return current thread priority */
+  return (prio);
+}
+
+/*
+  Pass control to next thread that is in state READY.
+*/
+osStatus_t osThreadYield (void) {
+  osStatus_t stat;
+
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  } else {
+    stat = osOK;
+    taskYIELD();
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+#if (configUSE_OS2_THREAD_SUSPEND_RESUME == 1)
+/*
+  Suspend execution of a thread.
+*/
+osStatus_t osThreadSuspend (osThreadId_t thread_id) {
+  TaskHandle_t hTask = (TaskHandle_t)thread_id;
+  osStatus_t stat;
+
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else if (hTask == NULL) {
+    stat = osErrorParameter;
+  }
+  else {
+    stat = osOK;
+    vTaskSuspend (hTask);
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Resume execution of a thread.
+*/
+osStatus_t osThreadResume (osThreadId_t thread_id) {
+  TaskHandle_t hTask = (TaskHandle_t)thread_id;
+  osStatus_t stat;
+
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else if (hTask == NULL) {
+    stat = osErrorParameter;
+  }
+  else {
+    stat = osOK;
+    vTaskResume (hTask);
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+#endif /* (configUSE_OS2_THREAD_SUSPEND_RESUME == 1) */
+
+/*
+  Terminate execution of current running thread.
+*/
+__NO_RETURN void osThreadExit (void) {
+#ifndef USE_FreeRTOS_HEAP_1
+  vTaskDelete (NULL);
+#endif
+  for (;;);
+}
+
+/*
+  Terminate execution of a thread.
+*/
+osStatus_t osThreadTerminate (osThreadId_t thread_id) {
+  TaskHandle_t hTask = (TaskHandle_t)thread_id;
+  osStatus_t stat;
+#ifndef USE_FreeRTOS_HEAP_1
+  eTaskState tstate;
+
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else if (hTask == NULL) {
+    stat = osErrorParameter;
+  }
+  else {
+    tstate = eTaskGetState (hTask);
+
+    if (tstate != eDeleted) {
+      stat = osOK;
+      vTaskDelete (hTask);
+    } else {
+      stat = osErrorResource;
+    }
+  }
+#else
+  stat = osError;
+#endif
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Get number of active threads.
+*/
+uint32_t osThreadGetCount (void) {
+  uint32_t count;
+
+  if (IRQ_Context() != 0U) {
+    count = 0U;
+  } else {
+    count = uxTaskGetNumberOfTasks();
+  }
+
+  /* Return number of active threads */
+  return (count);
+}
+
+#if (configUSE_OS2_THREAD_ENUMERATE == 1)
+/*
+  Enumerate active threads.
+*/
+uint32_t osThreadEnumerate (osThreadId_t *thread_array, uint32_t array_items) {
+  uint32_t i, count;
+  TaskStatus_t *task;
+
+  if ((IRQ_Context() != 0U) || (thread_array == NULL) || (array_items == 0U)) {
+    count = 0U;
+  } else {
+    vTaskSuspendAll();
+
+    /* Allocate memory on heap to temporarily store TaskStatus_t information */
+    count = uxTaskGetNumberOfTasks();
+    task  = pvPortMalloc (count * sizeof(TaskStatus_t));
+
+    if (task != NULL) {
+      /* Retrieve task status information */
+      count = uxTaskGetSystemState (task, count, NULL);
+
+      /* Copy handles from task status array into provided thread array */
+      for (i = 0U; (i < count) && (i < array_items); i++) {
+        thread_array[i] = (osThreadId_t)task[i].xHandle;
+      }
+      count = i;
+    }
+    (void)xTaskResumeAll();
+
+    vPortFree (task);
+  }
+
+  /* Return number of enumerated threads */
+  return (count);
+}
+#endif /* (configUSE_OS2_THREAD_ENUMERATE == 1) */
+
+
+/* ==== Thread Flags Functions ==== */
+
+#if (configUSE_OS2_THREAD_FLAGS == 1)
+/*
+  Set the specified Thread Flags of a thread.
+*/
+uint32_t osThreadFlagsSet (osThreadId_t thread_id, uint32_t flags) {
+  TaskHandle_t hTask = (TaskHandle_t)thread_id;
+  uint32_t rflags;
+  BaseType_t yield;
+
+  if ((hTask == NULL) || ((flags & THREAD_FLAGS_INVALID_BITS) != 0U)) {
+    rflags = (uint32_t)osErrorParameter;
+  }
+  else {
+    rflags = (uint32_t)osError;
+
+    if (IRQ_Context() != 0U) {
+      yield = pdFALSE;
+
+      (void)xTaskNotifyFromISR (hTask, flags, eSetBits, &yield);
+      (void)xTaskNotifyAndQueryFromISR (hTask, 0, eNoAction, &rflags, NULL);
+
+      portYIELD_FROM_ISR (yield);
+    }
+    else {
+      (void)xTaskNotify (hTask, flags, eSetBits);
+      (void)xTaskNotifyAndQuery (hTask, 0, eNoAction, &rflags);
+    }
+  }
+  /* Return flags after setting */
+  return (rflags);
+}
+
+/*
+  Clear the specified Thread Flags of current running thread.
+*/
+uint32_t osThreadFlagsClear (uint32_t flags) {
+  TaskHandle_t hTask;
+  uint32_t rflags, cflags;
+
+  if (IRQ_Context() != 0U) {
+    rflags = (uint32_t)osErrorISR;
+  }
+  else if ((flags & THREAD_FLAGS_INVALID_BITS) != 0U) {
+    rflags = (uint32_t)osErrorParameter;
+  }
+  else {
+    hTask = xTaskGetCurrentTaskHandle();
+
+    if (xTaskNotifyAndQuery (hTask, 0, eNoAction, &cflags) == pdPASS) {
+      rflags = cflags;
+      cflags &= ~flags;
+
+      if (xTaskNotify (hTask, cflags, eSetValueWithOverwrite) != pdPASS) {
+        rflags = (uint32_t)osError;
+      }
+    }
+    else {
+      rflags = (uint32_t)osError;
+    }
+  }
+
+  /* Return flags before clearing */
+  return (rflags);
+}
+
+/*
+  Get the current Thread Flags of current running thread.
+*/
+uint32_t osThreadFlagsGet (void) {
+  TaskHandle_t hTask;
+  uint32_t rflags;
+
+  if (IRQ_Context() != 0U) {
+    rflags = (uint32_t)osErrorISR;
+  }
+  else {
+    hTask = xTaskGetCurrentTaskHandle();
+
+    if (xTaskNotifyAndQuery (hTask, 0, eNoAction, &rflags) != pdPASS) {
+      rflags = (uint32_t)osError;
+    }
+  }
+
+  /* Return current flags */
+  return (rflags);
+}
+
+/*
+  Wait for one or more Thread Flags of the current running thread to become signaled.
+*/
+uint32_t osThreadFlagsWait (uint32_t flags, uint32_t options, uint32_t timeout) {
+  uint32_t rflags, nval;
+  uint32_t clear;
+  TickType_t t0, td, tout;
+  BaseType_t rval;
+
+  if (IRQ_Context() != 0U) {
+    rflags = (uint32_t)osErrorISR;
+  }
+  else if ((flags & THREAD_FLAGS_INVALID_BITS) != 0U) {
+    rflags = (uint32_t)osErrorParameter;
+  }
+  else {
+    if ((options & osFlagsNoClear) == osFlagsNoClear) {
+      clear = 0U;
+    } else {
+      clear = flags;
+    }
+
+    rflags = 0U;
+    tout   = timeout;
+
+    t0 = xTaskGetTickCount();
+    do {
+      rval = xTaskNotifyWait (0, clear, &nval, tout);
+
+      if (rval == pdPASS) {
+        rflags &= flags;
+        rflags |= nval;
+
+        if ((options & osFlagsWaitAll) == osFlagsWaitAll) {
+          if ((flags & rflags) == flags) {
+            break;
+          } else {
+            if (timeout == 0U) {
+              rflags = (uint32_t)osErrorResource;
+              break;
+            }
+          }
+        }
+        else {
+          if ((flags & rflags) != 0) {
+            break;
+          } else {
+            if (timeout == 0U) {
+              rflags = (uint32_t)osErrorResource;
+              break;
+            }
+          }
+        }
+
+        /* Update timeout */
+        td = xTaskGetTickCount() - t0;
+
+        if (td > timeout) {
+          tout  = 0;
+        } else {
+          tout = timeout - td;
+        }
+      }
+      else {
+        if (timeout == 0) {
+          rflags = (uint32_t)osErrorResource;
+        } else {
+          rflags = (uint32_t)osErrorTimeout;
+        }
+      }
+    }
+    while (rval != pdFAIL);
+  }
+
+  /* Return flags before clearing */
+  return (rflags);
+}
+#endif /* (configUSE_OS2_THREAD_FLAGS == 1) */
+
+
+/* ==== Generic Wait Functions ==== */
+
+/*
+  Wait for Timeout (Time Delay).
+*/
+osStatus_t osDelay (uint32_t ticks) {
+  osStatus_t stat;
+
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else {
+    stat = osOK;
+
+    if (ticks != 0U) {
+      vTaskDelay(ticks);
+    }
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Wait until specified time.
+*/
+osStatus_t osDelayUntil (uint32_t ticks) {
+  TickType_t tcnt, delay;
+  osStatus_t stat;
+
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else {
+    stat = osOK;
+    tcnt = xTaskGetTickCount();
+
+    /* Determine remaining number of ticks to delay */
+    delay = (TickType_t)ticks - tcnt;
+
+    /* Check if target tick has not expired */
+    if((delay != 0U) && (0 == (delay >> (8 * sizeof(TickType_t) - 1)))) {
+      if (xTaskDelayUntil (&tcnt, delay) == pdFALSE) {
+        /* Did not delay */
+        stat = osError;
+      }
+    }
+    else
+    {
+      /* No delay or already expired */
+      stat = osErrorParameter;
+    }
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+
+/* ==== Timer Management Functions ==== */
+
+#if (configUSE_OS2_TIMER == 1)
+
+static void TimerCallback (TimerHandle_t hTimer) {
+  TimerCallback_t *callb;
+
+  /* Retrieve pointer to callback function and argument */
+  callb = (TimerCallback_t *)pvTimerGetTimerID (hTimer);
+
+  /* Remove dynamic allocation flag */
+  callb = (TimerCallback_t *)((uint32_t)callb & ~1U);
+
+  if (callb != NULL) {
+    callb->func (callb->arg);
+  }
+}
+
+/*
+  Create and Initialize a timer.
+*/
+osTimerId_t osTimerNew (osTimerFunc_t func, osTimerType_t type, void *argument, const osTimerAttr_t *attr) {
+  const char *name;
+  TimerHandle_t hTimer;
+  TimerCallback_t *callb;
+  UBaseType_t reload;
+  int32_t mem;
+  uint32_t callb_dyn;
+
+  hTimer = NULL;
+
+  if ((IRQ_Context() == 0U) && (func != NULL)) {
+    callb     = NULL;
+    callb_dyn = 0U;
+
+    #if (configSUPPORT_STATIC_ALLOCATION == 1)
+      /* Static memory allocation is available: check if memory for control block */
+      /* is provided and if it also contains space for callback and its argument  */
+      if ((attr != NULL) && (attr->cb_mem != NULL)) {
+        if (attr->cb_size >= (sizeof(StaticTimer_t) + sizeof(TimerCallback_t))) {
+          callb = (TimerCallback_t *)((uint32_t)attr->cb_mem + sizeof(StaticTimer_t));
+        }
+      }
+    #endif
+
+    #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+      /* Dynamic memory allocation is available: if memory for callback and */
+      /* its argument is not provided, allocate it from dynamic memory pool */
+      if (callb == NULL) {
+        callb = (TimerCallback_t *)pvPortMalloc (sizeof(TimerCallback_t));
+
+        if (callb != NULL) {
+          /* Callback memory was allocated from dynamic pool, set flag */
+          callb_dyn = 1U;
+        }
+      }
+    #endif
+
+    if (callb != NULL) {
+      callb->func = func;
+      callb->arg  = argument;
+
+      if (type == osTimerOnce) {
+        reload = pdFALSE;
+      } else {
+        reload = pdTRUE;
+      }
+
+      mem  = -1;
+      name = NULL;
+
+      if (attr != NULL) {
+        if (attr->name != NULL) {
+          name = attr->name;
+        }
+
+        if ((attr->cb_mem != NULL) && (attr->cb_size >= sizeof(StaticTimer_t))) {
+          /* The memory for control block is provided, use static object */
+          mem = 1;
+        }
+        else {
+          if ((attr->cb_mem == NULL) && (attr->cb_size == 0U)) {
+            /* Control block will be allocated from the dynamic pool */
+            mem = 0;
+          }
+        }
+      }
+      else {
+        mem = 0;
+      }
+      /* Store callback memory dynamic allocation flag */
+      callb = (TimerCallback_t *)((uint32_t)callb | callb_dyn);
+      /*
+        TimerCallback function is always provided as a callback and is used to call application
+        specified function with its argument both stored in structure callb.
+      */
+      if (mem == 1) {
+        #if (configSUPPORT_STATIC_ALLOCATION == 1)
+          hTimer = xTimerCreateStatic (name, 1, reload, callb, TimerCallback, (StaticTimer_t *)attr->cb_mem);
+        #endif
+      }
+      else {
+        if (mem == 0) {
+          #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+            hTimer = xTimerCreate (name, 1, reload, callb, TimerCallback);
+          #endif
+        }
+      }
+
+      #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+      if ((hTimer == NULL) && (callb != NULL) && (callb_dyn == 1U)) {
+        /* Failed to create a timer, release allocated resources */
+        callb = (TimerCallback_t *)((uint32_t)callb & ~1U);
+
+        vPortFree (callb);
+      }
+      #endif
+    }
+  }
+
+  /* Return timer ID */
+  return ((osTimerId_t)hTimer);
+}
+
+/*
+  Get name of a timer.
+*/
+const char *osTimerGetName (osTimerId_t timer_id) {
+  TimerHandle_t hTimer = (TimerHandle_t)timer_id;
+  const char *p;
+
+  if ((IRQ_Context() != 0U) || (hTimer == NULL)) {
+    p = NULL;
+  } else {
+    p = pcTimerGetName (hTimer);
+  }
+
+  /* Return name as null-terminated string */
+  return (p);
+}
+
+/*
+  Start or restart a timer.
+*/
+osStatus_t osTimerStart (osTimerId_t timer_id, uint32_t ticks) {
+  TimerHandle_t hTimer = (TimerHandle_t)timer_id;
+  osStatus_t stat;
+
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else if ((hTimer == NULL) || (ticks == 0U)) {
+    stat = osErrorParameter;
+  }
+  else {
+    if (xTimerChangePeriod (hTimer, ticks, 0) == pdPASS) {
+      stat = osOK;
+    } else {
+      stat = osErrorResource;
+    }
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Stop a timer.
+*/
+osStatus_t osTimerStop (osTimerId_t timer_id) {
+  TimerHandle_t hTimer = (TimerHandle_t)timer_id;
+  osStatus_t stat;
+
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else if (hTimer == NULL) {
+    stat = osErrorParameter;
+  }
+  else {
+    if (xTimerIsTimerActive (hTimer) == pdFALSE) {
+      stat = osErrorResource;
+    }
+    else {
+      if (xTimerStop (hTimer, 0) == pdPASS) {
+        stat = osOK;
+      } else {
+        stat = osError;
+      }
+    }
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Check if a timer is running.
+*/
+uint32_t osTimerIsRunning (osTimerId_t timer_id) {
+  TimerHandle_t hTimer = (TimerHandle_t)timer_id;
+  uint32_t running;
+
+  if ((IRQ_Context() != 0U) || (hTimer == NULL)) {
+    running = 0U;
+  } else {
+    running = (uint32_t)xTimerIsTimerActive (hTimer);
+  }
+
+  /* Return 0: not running, 1: running */
+  return (running);
+}
+
+/*
+  Delete a timer.
+*/
+osStatus_t osTimerDelete (osTimerId_t timer_id) {
+  TimerHandle_t hTimer = (TimerHandle_t)timer_id;
+  osStatus_t stat;
+#ifndef USE_FreeRTOS_HEAP_1
+#if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+  TimerCallback_t *callb;
+#endif
+
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else if (hTimer == NULL) {
+    stat = osErrorParameter;
+  }
+  else {
+    #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+    callb = (TimerCallback_t *)pvTimerGetTimerID (hTimer);
+    #endif
+
+    if (xTimerDelete (hTimer, 0) == pdPASS) {
+      #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+        if ((uint32_t)callb & 1U) {
+          /* Callback memory was allocated from dynamic pool, clear flag */
+          callb = (TimerCallback_t *)((uint32_t)callb & ~1U);
+
+          /* Return allocated memory to dynamic pool */
+          vPortFree (callb);
+        }
+      #endif
+      stat = osOK;
+    } else {
+      stat = osErrorResource;
+    }
+  }
+#else
+  stat = osError;
+#endif
+
+  /* Return execution status */
+  return (stat);
+}
+#endif /* (configUSE_OS2_TIMER == 1) */
+
+
+/* ==== Event Flags Management Functions ==== */
+
+/*
+  Create and Initialize an Event Flags object.
+
+  Limitations:
+  - Event flags are limited to 24 bits.
+*/
+osEventFlagsId_t osEventFlagsNew (const osEventFlagsAttr_t *attr) {
+  EventGroupHandle_t hEventGroup;
+  int32_t mem;
+
+  hEventGroup = NULL;
+
+  if (IRQ_Context() == 0U) {
+    mem = -1;
+
+    if (attr != NULL) {
+      if ((attr->cb_mem != NULL) && (attr->cb_size >= sizeof(StaticEventGroup_t))) {
+        /* The memory for control block is provided, use static object */
+        mem = 1;
+      }
+      else {
+        if ((attr->cb_mem == NULL) && (attr->cb_size == 0U)) {
+          /* Control block will be allocated from the dynamic pool */
+          mem = 0;
+        }
+      }
+    }
+    else {
+      mem = 0;
+    }
+
+    if (mem == 1) {
+      #if (configSUPPORT_STATIC_ALLOCATION == 1)
+      hEventGroup = xEventGroupCreateStatic (attr->cb_mem);
+      #endif
+    }
+    else {
+      if (mem == 0) {
+        #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+          hEventGroup = xEventGroupCreate();
+        #endif
+      }
+    }
+  }
+
+  /* Return event flags ID */
+  return ((osEventFlagsId_t)hEventGroup);
+}
+
+/*
+  Set the specified Event Flags.
+
+  Limitations:
+  - Event flags are limited to 24 bits.
+*/
+uint32_t osEventFlagsSet (osEventFlagsId_t ef_id, uint32_t flags) {
+  EventGroupHandle_t hEventGroup = (EventGroupHandle_t)ef_id;
+  uint32_t rflags;
+  BaseType_t yield;
+
+  if ((hEventGroup == NULL) || ((flags & EVENT_FLAGS_INVALID_BITS) != 0U)) {
+    rflags = (uint32_t)osErrorParameter;
+  }
+  else if (IRQ_Context() != 0U) {
+  #if (configUSE_OS2_EVENTFLAGS_FROM_ISR == 0)
+    (void)yield;
+    /* Enable timers and xTimerPendFunctionCall function to support osEventFlagsSet from ISR */
+    rflags = (uint32_t)osErrorResource;
+  #else
+    yield = pdFALSE;
+
+    if (xEventGroupSetBitsFromISR (hEventGroup, (EventBits_t)flags, &yield) == pdFAIL) {
+      rflags = (uint32_t)osErrorResource;
+    } else {
+      /* Retrieve bits that are already set and add flags to be set in current call */
+      rflags  = xEventGroupGetBitsFromISR (hEventGroup);
+      rflags |= flags;
+      portYIELD_FROM_ISR (yield);
+    }
+  #endif
+  }
+  else {
+    rflags = xEventGroupSetBits (hEventGroup, (EventBits_t)flags);
+  }
+
+  /* Return event flags after setting */
+  return (rflags);
+}
+
+/*
+  Clear the specified Event Flags.
+
+  Limitations:
+  - Event flags are limited to 24 bits.
+*/
+uint32_t osEventFlagsClear (osEventFlagsId_t ef_id, uint32_t flags) {
+  EventGroupHandle_t hEventGroup = (EventGroupHandle_t)ef_id;
+  uint32_t rflags;
+
+  if ((hEventGroup == NULL) || ((flags & EVENT_FLAGS_INVALID_BITS) != 0U)) {
+    rflags = (uint32_t)osErrorParameter;
+  }
+  else if (IRQ_Context() != 0U) {
+  #if (configUSE_OS2_EVENTFLAGS_FROM_ISR == 0)
+    /* Enable timers and xTimerPendFunctionCall function to support osEventFlagsSet from ISR */
+    rflags = (uint32_t)osErrorResource;
+  #else
+    rflags = xEventGroupGetBitsFromISR (hEventGroup);
+
+    if (xEventGroupClearBitsFromISR (hEventGroup, (EventBits_t)flags) == pdFAIL) {
+      rflags = (uint32_t)osErrorResource;
+    }
+    else {
+      /* xEventGroupClearBitsFromISR only registers clear operation in the timer command queue. */
+      /* Yield is required here otherwise clear operation might not execute in the right order. */
+      /* See https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/93 for more info.               */
+      portYIELD_FROM_ISR (pdTRUE);
+    }
+  #endif
+  }
+  else {
+    rflags = xEventGroupClearBits (hEventGroup, (EventBits_t)flags);
+  }
+
+  /* Return event flags before clearing */
+  return (rflags);
+}
+
+/*
+  Get the current Event Flags.
+
+  Limitations:
+  - Event flags are limited to 24 bits.
+*/
+uint32_t osEventFlagsGet (osEventFlagsId_t ef_id) {
+  EventGroupHandle_t hEventGroup = (EventGroupHandle_t)ef_id;
+  uint32_t rflags;
+
+  if (ef_id == NULL) {
+    rflags = 0U;
+  }
+  else if (IRQ_Context() != 0U) {
+    rflags = xEventGroupGetBitsFromISR (hEventGroup);
+  }
+  else {
+    rflags = xEventGroupGetBits (hEventGroup);
+  }
+
+  /* Return current event flags */
+  return (rflags);
+}
+
+/*
+  Wait for one or more Event Flags to become signaled.
+
+  Limitations:
+  - Event flags are limited to 24 bits.
+  - osEventFlagsWait cannot be called from an ISR.
+*/
+uint32_t osEventFlagsWait (osEventFlagsId_t ef_id, uint32_t flags, uint32_t options, uint32_t timeout) {
+  EventGroupHandle_t hEventGroup = (EventGroupHandle_t)ef_id;
+  BaseType_t wait_all;
+  BaseType_t exit_clr;
+  uint32_t rflags;
+
+  if ((hEventGroup == NULL) || ((flags & EVENT_FLAGS_INVALID_BITS) != 0U)) {
+    rflags = (uint32_t)osErrorParameter;
+  }
+  else if (IRQ_Context() != 0U) {
+    if (timeout == 0U) {
+      /* Try semantic is not supported */
+      rflags = (uint32_t)osErrorISR;
+    } else {
+      /* Calling osEventFlagsWait from ISR with non-zero timeout is invalid */
+      rflags = (uint32_t)osFlagsErrorParameter;
+    }
+  }
+  else {
+    if (options & osFlagsWaitAll) {
+      wait_all = pdTRUE;
+    } else {
+      wait_all = pdFAIL;
+    }
+
+    if (options & osFlagsNoClear) {
+      exit_clr = pdFAIL;
+    } else {
+      exit_clr = pdTRUE;
+    }
+
+    rflags = xEventGroupWaitBits (hEventGroup, (EventBits_t)flags, exit_clr, wait_all, (TickType_t)timeout);
+
+    if (options & osFlagsWaitAll) {
+      if ((flags & rflags) != flags) {
+        if (timeout > 0U) {
+          rflags = (uint32_t)osErrorTimeout;
+        } else {
+          rflags = (uint32_t)osErrorResource;
+        }
+      }
+    }
+    else {
+      if ((flags & rflags) == 0U) {
+        if (timeout > 0U) {
+          rflags = (uint32_t)osErrorTimeout;
+        } else {
+          rflags = (uint32_t)osErrorResource;
+        }
+      }
+    }
+  }
+
+  /* Return event flags before clearing */
+  return (rflags);
+}
+
+/*
+  Delete an Event Flags object.
+*/
+osStatus_t osEventFlagsDelete (osEventFlagsId_t ef_id) {
+  EventGroupHandle_t hEventGroup = (EventGroupHandle_t)ef_id;
+  osStatus_t stat;
+
+#ifndef USE_FreeRTOS_HEAP_1
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else if (hEventGroup == NULL) {
+    stat = osErrorParameter;
+  }
+  else {
+    stat = osOK;
+    vEventGroupDelete (hEventGroup);
+  }
+#else
+  stat = osError;
+#endif
+
+  /* Return execution status */
+  return (stat);
+}
+
+
+/* ==== Mutex Management Functions ==== */
+
+#if (configUSE_OS2_MUTEX == 1)
+/*
+  Create and Initialize a Mutex object.
+
+  Limitations:
+  - Priority inherit protocol is used by default, osMutexPrioInherit attribute is ignored.
+  - Robust mutex is not supported, NULL is returned if used.
+*/
+osMutexId_t osMutexNew (const osMutexAttr_t *attr) {
+  SemaphoreHandle_t hMutex;
+  uint32_t type;
+  uint32_t rmtx;
+  int32_t  mem;
+
+  hMutex = NULL;
+
+  if (IRQ_Context() == 0U) {
+    if (attr != NULL) {
+      type = attr->attr_bits;
+    } else {
+      type = 0U;
+    }
+
+    if ((type & osMutexRecursive) == osMutexRecursive) {
+      rmtx = 1U;
+    } else {
+      rmtx = 0U;
+    }
+
+    if ((type & osMutexRobust) != osMutexRobust) {
+      mem = -1;
+
+      if (attr != NULL) {
+        if ((attr->cb_mem != NULL) && (attr->cb_size >= sizeof(StaticSemaphore_t))) {
+          /* The memory for control block is provided, use static object */
+          mem = 1;
+        }
+        else {
+          if ((attr->cb_mem == NULL) && (attr->cb_size == 0U)) {
+            /* Control block will be allocated from the dynamic pool */
+            mem = 0;
+          }
+        }
+      }
+      else {
+        mem = 0;
+      }
+
+      if (mem == 1) {
+        #if (configSUPPORT_STATIC_ALLOCATION == 1)
+          if (rmtx != 0U) {
+            #if (configUSE_RECURSIVE_MUTEXES == 1)
+            hMutex = xSemaphoreCreateRecursiveMutexStatic (attr->cb_mem);
+            #endif
+          }
+          else {
+            hMutex = xSemaphoreCreateMutexStatic (attr->cb_mem);
+          }
+        #endif
+      }
+      else {
+        if (mem == 0) {
+          #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+            if (rmtx != 0U) {
+              #if (configUSE_RECURSIVE_MUTEXES == 1)
+              hMutex = xSemaphoreCreateRecursiveMutex ();
+              #endif
+            } else {
+              hMutex = xSemaphoreCreateMutex ();
+            }
+          #endif
+        }
+      }
+
+      #if (configQUEUE_REGISTRY_SIZE > 0)
+      if (hMutex != NULL) {
+        if ((attr != NULL) && (attr->name != NULL)) {
+          /* Only non-NULL name objects are added to the Queue Registry */
+          vQueueAddToRegistry (hMutex, attr->name);
+        }
+      }
+      #endif
+
+      if ((hMutex != NULL) && (rmtx != 0U)) {
+        /* Set LSB as 'recursive mutex flag' */
+        hMutex = (SemaphoreHandle_t)((uint32_t)hMutex | 1U);
+      }
+    }
+  }
+
+  /* Return mutex ID */
+  return ((osMutexId_t)hMutex);
+}
+
+/*
+  Acquire a Mutex or timeout if it is locked.
+*/
+osStatus_t osMutexAcquire (osMutexId_t mutex_id, uint32_t timeout) {
+  SemaphoreHandle_t hMutex;
+  osStatus_t stat;
+  uint32_t rmtx;
+
+  hMutex = (SemaphoreHandle_t)((uint32_t)mutex_id & ~1U);
+
+  /* Extract recursive mutex flag */
+  rmtx = (uint32_t)mutex_id & 1U;
+
+  stat = osOK;
+
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else if (hMutex == NULL) {
+    stat = osErrorParameter;
+  }
+  else {
+    if (rmtx != 0U) {
+      #if (configUSE_RECURSIVE_MUTEXES == 1)
+      if (xSemaphoreTakeRecursive (hMutex, timeout) != pdPASS) {
+        if (timeout != 0U) {
+          stat = osErrorTimeout;
+        } else {
+          stat = osErrorResource;
+        }
+      }
+      #endif
+    }
+    else {
+      if (xSemaphoreTake (hMutex, timeout) != pdPASS) {
+        if (timeout != 0U) {
+          stat = osErrorTimeout;
+        } else {
+          stat = osErrorResource;
+        }
+      }
+    }
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Release a Mutex that was acquired by osMutexAcquire.
+*/
+osStatus_t osMutexRelease (osMutexId_t mutex_id) {
+  SemaphoreHandle_t hMutex;
+  osStatus_t stat;
+  uint32_t rmtx;
+
+  hMutex = (SemaphoreHandle_t)((uint32_t)mutex_id & ~1U);
+
+  /* Extract recursive mutex flag */
+  rmtx = (uint32_t)mutex_id & 1U;
+
+  stat = osOK;
+
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else if (hMutex == NULL) {
+    stat = osErrorParameter;
+  }
+  else {
+    if (rmtx != 0U) {
+      #if (configUSE_RECURSIVE_MUTEXES == 1)
+      if (xSemaphoreGiveRecursive (hMutex) != pdPASS) {
+        stat = osErrorResource;
+      }
+      #endif
+    }
+    else {
+      if (xSemaphoreGive (hMutex) != pdPASS) {
+        stat = osErrorResource;
+      }
+    }
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Get Thread which owns a Mutex object.
+*/
+osThreadId_t osMutexGetOwner (osMutexId_t mutex_id) {
+  SemaphoreHandle_t hMutex;
+  osThreadId_t owner;
+
+  hMutex = (SemaphoreHandle_t)((uint32_t)mutex_id & ~1U);
+
+  if ((IRQ_Context() != 0U) || (hMutex == NULL)) {
+    owner = NULL;
+  } else {
+    owner = (osThreadId_t)xSemaphoreGetMutexHolder (hMutex);
+  }
+
+  /* Return owner thread ID */
+  return (owner);
+}
+
+/*
+  Delete a Mutex object.
+*/
+osStatus_t osMutexDelete (osMutexId_t mutex_id) {
+  osStatus_t stat;
+#ifndef USE_FreeRTOS_HEAP_1
+  SemaphoreHandle_t hMutex;
+
+  hMutex = (SemaphoreHandle_t)((uint32_t)mutex_id & ~1U);
+
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else if (hMutex == NULL) {
+    stat = osErrorParameter;
+  }
+  else {
+    #if (configQUEUE_REGISTRY_SIZE > 0)
+    vQueueUnregisterQueue (hMutex);
+    #endif
+    stat = osOK;
+    vSemaphoreDelete (hMutex);
+  }
+#else
+  stat = osError;
+#endif
+
+  /* Return execution status */
+  return (stat);
+}
+#endif /* (configUSE_OS2_MUTEX == 1) */
+
+
+/* ==== Semaphore Management Functions ==== */
+
+/*
+  Create and Initialize a Semaphore object.
+*/
+osSemaphoreId_t osSemaphoreNew (uint32_t max_count, uint32_t initial_count, const osSemaphoreAttr_t *attr) {
+  SemaphoreHandle_t hSemaphore;
+  int32_t mem;
+
+  hSemaphore = NULL;
+
+  if ((IRQ_Context() == 0U) && (max_count > 0U) && (initial_count <= max_count)) {
+    mem = -1;
+
+    if (attr != NULL) {
+      if ((attr->cb_mem != NULL) && (attr->cb_size >= sizeof(StaticSemaphore_t))) {
+        /* The memory for control block is provided, use static object */
+        mem = 1;
+      }
+      else {
+        if ((attr->cb_mem == NULL) && (attr->cb_size == 0U)) {
+          /* Control block will be allocated from the dynamic pool */
+          mem = 0;
+        }
+      }
+    }
+    else {
+      mem = 0;
+    }
+
+    if (mem != -1) {
+      if (max_count == 1U) {
+        if (mem == 1) {
+          #if (configSUPPORT_STATIC_ALLOCATION == 1)
+            hSemaphore = xSemaphoreCreateBinaryStatic ((StaticSemaphore_t *)attr->cb_mem);
+          #endif
+        }
+        else {
+          #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+            hSemaphore = xSemaphoreCreateBinary();
+          #endif
+        }
+
+        if ((hSemaphore != NULL) && (initial_count != 0U)) {
+          if (xSemaphoreGive (hSemaphore) != pdPASS) {
+            vSemaphoreDelete (hSemaphore);
+            hSemaphore = NULL;
+          }
+        }
+      }
+      else {
+        if (mem == 1) {
+          #if (configSUPPORT_STATIC_ALLOCATION == 1)
+            hSemaphore = xSemaphoreCreateCountingStatic (max_count, initial_count, (StaticSemaphore_t *)attr->cb_mem);
+          #endif
+        }
+        else {
+          #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+            hSemaphore = xSemaphoreCreateCounting (max_count, initial_count);
+          #endif
+        }
+      }
+
+      #if (configQUEUE_REGISTRY_SIZE > 0)
+      if (hSemaphore != NULL) {
+        if ((attr != NULL) && (attr->name != NULL)) {
+          /* Only non-NULL name objects are added to the Queue Registry */
+          vQueueAddToRegistry (hSemaphore, attr->name);
+        }
+      }
+      #endif
+    }
+  }
+
+  /* Return semaphore ID */
+  return ((osSemaphoreId_t)hSemaphore);
+}
+
+/*
+  Acquire a Semaphore token or timeout if no tokens are available.
+*/
+osStatus_t osSemaphoreAcquire (osSemaphoreId_t semaphore_id, uint32_t timeout) {
+  SemaphoreHandle_t hSemaphore = (SemaphoreHandle_t)semaphore_id;
+  osStatus_t stat;
+  BaseType_t yield;
+
+  stat = osOK;
+
+  if (hSemaphore == NULL) {
+    stat = osErrorParameter;
+  }
+  else if (IRQ_Context() != 0U) {
+    if (timeout != 0U) {
+      stat = osErrorParameter;
+    }
+    else {
+      yield = pdFALSE;
+
+      if (xSemaphoreTakeFromISR (hSemaphore, &yield) != pdPASS) {
+        stat = osErrorResource;
+      } else {
+        portYIELD_FROM_ISR (yield);
+      }
+    }
+  }
+  else {
+    if (xSemaphoreTake (hSemaphore, (TickType_t)timeout) != pdPASS) {
+      if (timeout != 0U) {
+        stat = osErrorTimeout;
+      } else {
+        stat = osErrorResource;
+      }
+    }
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Release a Semaphore token up to the initial maximum count.
+*/
+osStatus_t osSemaphoreRelease (osSemaphoreId_t semaphore_id) {
+  SemaphoreHandle_t hSemaphore = (SemaphoreHandle_t)semaphore_id;
+  osStatus_t stat;
+  BaseType_t yield;
+
+  stat = osOK;
+
+  if (hSemaphore == NULL) {
+    stat = osErrorParameter;
+  }
+  else if (IRQ_Context() != 0U) {
+    yield = pdFALSE;
+
+    if (xSemaphoreGiveFromISR (hSemaphore, &yield) != pdTRUE) {
+      stat = osErrorResource;
+    } else {
+      portYIELD_FROM_ISR (yield);
+    }
+  }
+  else {
+    if (xSemaphoreGive (hSemaphore) != pdPASS) {
+      stat = osErrorResource;
+    }
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Get current Semaphore token count.
+*/
+uint32_t osSemaphoreGetCount (osSemaphoreId_t semaphore_id) {
+  SemaphoreHandle_t hSemaphore = (SemaphoreHandle_t)semaphore_id;
+  uint32_t count;
+
+  if (hSemaphore == NULL) {
+    count = 0U;
+  }
+  else if (IRQ_Context() != 0U) {
+    count = (uint32_t)uxSemaphoreGetCountFromISR (hSemaphore);
+  } else {
+    count = (uint32_t)uxSemaphoreGetCount (hSemaphore);
+  }
+
+  /* Return number of tokens */
+  return (count);
+}
+
+/*
+  Delete a Semaphore object.
+*/
+osStatus_t osSemaphoreDelete (osSemaphoreId_t semaphore_id) {
+  SemaphoreHandle_t hSemaphore = (SemaphoreHandle_t)semaphore_id;
+  osStatus_t stat;
+
+#ifndef USE_FreeRTOS_HEAP_1
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else if (hSemaphore == NULL) {
+    stat = osErrorParameter;
+  }
+  else {
+    #if (configQUEUE_REGISTRY_SIZE > 0)
+    vQueueUnregisterQueue (hSemaphore);
+    #endif
+
+    stat = osOK;
+    vSemaphoreDelete (hSemaphore);
+  }
+#else
+  stat = osError;
+#endif
+
+  /* Return execution status */
+  return (stat);
+}
+
+
+/* ==== Message Queue Management Functions ==== */
+
+/*
+  Create and Initialize a Message Queue object.
+
+  Limitations:
+  - The memory for control block and and message data must be provided in the
+    osThreadAttr_t structure in order to allocate object statically.
+*/
+osMessageQueueId_t osMessageQueueNew (uint32_t msg_count, uint32_t msg_size, const osMessageQueueAttr_t *attr) {
+  QueueHandle_t hQueue;
+  int32_t mem;
+
+  hQueue = NULL;
+
+  if ((IRQ_Context() == 0U) && (msg_count > 0U) && (msg_size > 0U)) {
+    mem = -1;
+
+    if (attr != NULL) {
+      if ((attr->cb_mem != NULL) && (attr->cb_size >= sizeof(StaticQueue_t)) &&
+          (attr->mq_mem != NULL) && (attr->mq_size >= (msg_count * msg_size))) {
+        /* The memory for control block and message data is provided, use static object */
+        mem = 1;
+      }
+      else {
+        if ((attr->cb_mem == NULL) && (attr->cb_size == 0U) &&
+            (attr->mq_mem == NULL) && (attr->mq_size == 0U)) {
+          /* Control block will be allocated from the dynamic pool */
+          mem = 0;
+        }
+      }
+    }
+    else {
+      mem = 0;
+    }
+
+    if (mem == 1) {
+      #if (configSUPPORT_STATIC_ALLOCATION == 1)
+        hQueue = xQueueCreateStatic (msg_count, msg_size, attr->mq_mem, attr->cb_mem);
+      #endif
+    }
+    else {
+      if (mem == 0) {
+        #if (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+          hQueue = xQueueCreate (msg_count, msg_size);
+        #endif
+      }
+    }
+
+    #if (configQUEUE_REGISTRY_SIZE > 0)
+    if (hQueue != NULL) {
+      if ((attr != NULL) && (attr->name != NULL)) {
+        /* Only non-NULL name objects are added to the Queue Registry */
+        vQueueAddToRegistry (hQueue, attr->name);
+      }
+    }
+    #endif
+
+  }
+
+  /* Return message queue ID */
+  return ((osMessageQueueId_t)hQueue);
+}
+
+/*
+  Put a Message into a Queue or timeout if Queue is full.
+
+  Limitations:
+  - Message priority is ignored
+*/
+osStatus_t osMessageQueuePut (osMessageQueueId_t mq_id, const void *msg_ptr, uint8_t msg_prio, uint32_t timeout) {
+  QueueHandle_t hQueue = (QueueHandle_t)mq_id;
+  osStatus_t stat;
+  BaseType_t yield;
+
+  (void)msg_prio; /* Message priority is ignored */
+
+  stat = osOK;
+
+  if (IRQ_Context() != 0U) {
+    if ((hQueue == NULL) || (msg_ptr == NULL) || (timeout != 0U)) {
+      stat = osErrorParameter;
+    }
+    else {
+      yield = pdFALSE;
+
+      if (xQueueSendToBackFromISR (hQueue, msg_ptr, &yield) != pdTRUE) {
+        stat = osErrorResource;
+      } else {
+        portYIELD_FROM_ISR (yield);
+      }
+    }
+  }
+  else {
+    if ((hQueue == NULL) || (msg_ptr == NULL)) {
+      stat = osErrorParameter;
+    }
+    else {
+      if (xQueueSendToBack (hQueue, msg_ptr, (TickType_t)timeout) != pdPASS) {
+        if (timeout != 0U) {
+          stat = osErrorTimeout;
+        } else {
+          stat = osErrorResource;
+        }
+      }
+    }
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Get a Message from a Queue or timeout if Queue is empty.
+
+  Limitations:
+  - Message priority is ignored
+*/
+osStatus_t osMessageQueueGet (osMessageQueueId_t mq_id, void *msg_ptr, uint8_t *msg_prio, uint32_t timeout) {
+  QueueHandle_t hQueue = (QueueHandle_t)mq_id;
+  osStatus_t stat;
+  BaseType_t yield;
+
+  (void)msg_prio; /* Message priority is ignored */
+
+  stat = osOK;
+
+  if (IRQ_Context() != 0U) {
+    if ((hQueue == NULL) || (msg_ptr == NULL) || (timeout != 0U)) {
+      stat = osErrorParameter;
+    }
+    else {
+      yield = pdFALSE;
+
+      if (xQueueReceiveFromISR (hQueue, msg_ptr, &yield) != pdPASS) {
+        stat = osErrorResource;
+      } else {
+        portYIELD_FROM_ISR (yield);
+      }
+    }
+  }
+  else {
+    if ((hQueue == NULL) || (msg_ptr == NULL)) {
+      stat = osErrorParameter;
+    }
+    else {
+      if (xQueueReceive (hQueue, msg_ptr, (TickType_t)timeout) != pdPASS) {
+        if (timeout != 0U) {
+          stat = osErrorTimeout;
+        } else {
+          stat = osErrorResource;
+        }
+      }
+    }
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Get maximum number of messages in a Message Queue.
+*/
+uint32_t osMessageQueueGetCapacity (osMessageQueueId_t mq_id) {
+  StaticQueue_t *mq = (StaticQueue_t *)mq_id;
+  uint32_t capacity;
+
+  if (mq == NULL) {
+    capacity = 0U;
+  } else {
+    /* capacity = pxQueue->uxLength */
+    capacity = mq->uxDummy4[1];
+  }
+
+  /* Return maximum number of messages */
+  return (capacity);
+}
+
+/*
+  Get maximum message size in a Message Queue.
+*/
+uint32_t osMessageQueueGetMsgSize (osMessageQueueId_t mq_id) {
+  StaticQueue_t *mq = (StaticQueue_t *)mq_id;
+  uint32_t size;
+
+  if (mq == NULL) {
+    size = 0U;
+  } else {
+    /* size = pxQueue->uxItemSize */
+    size = mq->uxDummy4[2];
+  }
+
+  /* Return maximum message size */
+  return (size);
+}
+
+/*
+  Get number of queued messages in a Message Queue.
+*/
+uint32_t osMessageQueueGetCount (osMessageQueueId_t mq_id) {
+  QueueHandle_t hQueue = (QueueHandle_t)mq_id;
+  UBaseType_t count;
+
+  if (hQueue == NULL) {
+    count = 0U;
+  }
+  else if (IRQ_Context() != 0U) {
+    count = uxQueueMessagesWaitingFromISR (hQueue);
+  }
+  else {
+    count = uxQueueMessagesWaiting (hQueue);
+  }
+
+  /* Return number of queued messages */
+  return ((uint32_t)count);
+}
+
+/*
+  Get number of available slots for messages in a Message Queue.
+*/
+uint32_t osMessageQueueGetSpace (osMessageQueueId_t mq_id) {
+  StaticQueue_t *mq = (StaticQueue_t *)mq_id;
+  uint32_t space;
+  uint32_t isrm;
+
+  if (mq == NULL) {
+    space = 0U;
+  }
+  else if (IRQ_Context() != 0U) {
+    isrm = taskENTER_CRITICAL_FROM_ISR();
+
+    /* space = pxQueue->uxLength - pxQueue->uxMessagesWaiting; */
+    space = mq->uxDummy4[1] - mq->uxDummy4[0];
+
+    taskEXIT_CRITICAL_FROM_ISR(isrm);
+  }
+  else {
+    space = (uint32_t)uxQueueSpacesAvailable ((QueueHandle_t)mq);
+  }
+
+  /* Return number of available slots */
+  return (space);
+}
+
+/*
+  Reset a Message Queue to initial empty state.
+*/
+osStatus_t osMessageQueueReset (osMessageQueueId_t mq_id) {
+  QueueHandle_t hQueue = (QueueHandle_t)mq_id;
+  osStatus_t stat;
+
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else if (hQueue == NULL) {
+    stat = osErrorParameter;
+  }
+  else {
+    stat = osOK;
+    (void)xQueueReset (hQueue);
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Delete a Message Queue object.
+*/
+osStatus_t osMessageQueueDelete (osMessageQueueId_t mq_id) {
+  QueueHandle_t hQueue = (QueueHandle_t)mq_id;
+  osStatus_t stat;
+
+#ifndef USE_FreeRTOS_HEAP_1
+  if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else if (hQueue == NULL) {
+    stat = osErrorParameter;
+  }
+  else {
+    #if (configQUEUE_REGISTRY_SIZE > 0)
+    vQueueUnregisterQueue (hQueue);
+    #endif
+
+    stat = osOK;
+    vQueueDelete (hQueue);
+  }
+#else
+  stat = osError;
+#endif
+
+  /* Return execution status */
+  return (stat);
+}
+
+
+/* ==== Memory Pool Management Functions ==== */
+
+#ifdef FREERTOS_MPOOL_H_
+/* Static memory pool functions */
+static void  FreeBlock   (MemPool_t *mp, void *block);
+static void *AllocBlock  (MemPool_t *mp);
+static void *CreateBlock (MemPool_t *mp);
+
+/*
+  Create and Initialize a Memory Pool object.
+*/
+osMemoryPoolId_t osMemoryPoolNew (uint32_t block_count, uint32_t block_size, const osMemoryPoolAttr_t *attr) {
+  MemPool_t *mp;
+  const char *name;
+  int32_t mem_cb, mem_mp;
+  uint32_t sz;
+
+  if (IRQ_Context() != 0U) {
+    mp = NULL;
+  }
+  else if ((block_count == 0U) || (block_size == 0U)) {
+    mp = NULL;
+  }
+  else {
+    mp = NULL;
+    sz = MEMPOOL_ARR_SIZE (block_count, block_size);
+
+    name = NULL;
+    mem_cb = -1;
+    mem_mp = -1;
+
+    if (attr != NULL) {
+      if (attr->name != NULL) {
+        name = attr->name;
+      }
+
+      if ((attr->cb_mem != NULL) && (attr->cb_size >= sizeof(MemPool_t))) {
+        /* Static control block is provided */
+        mem_cb = 1;
+      }
+      else if ((attr->cb_mem == NULL) && (attr->cb_size == 0U)) {
+        /* Allocate control block memory on heap */
+        mem_cb = 0;
+      }
+
+      if ((attr->mp_mem == NULL) && (attr->mp_size == 0U)) {
+        /* Allocate memory array on heap */
+          mem_mp = 0;
+      }
+      else {
+        if (attr->mp_mem != NULL) {
+          /* Check if array is 4-byte aligned */
+          if (((uint32_t)attr->mp_mem & 3U) == 0U) {
+            /* Check if array big enough */
+            if (attr->mp_size >= sz) {
+              /* Static memory pool array is provided */
+              mem_mp = 1;
+            }
+          }
+        }
+      }
+    }
+    else {
+      /* Attributes not provided, allocate memory on heap */
+      mem_cb = 0;
+      mem_mp = 0;
+    }
+
+    if (mem_cb == 0) {
+      mp = pvPortMalloc (sizeof(MemPool_t));
+    } else {
+      mp = attr->cb_mem;
+    }
+
+    if (mp != NULL) {
+      /* Create a semaphore (max count == initial count == block_count) */
+      #if (configSUPPORT_STATIC_ALLOCATION == 1)
+        mp->sem = xSemaphoreCreateCountingStatic (block_count, block_count, &mp->mem_sem);
+      #elif (configSUPPORT_DYNAMIC_ALLOCATION == 1)
+        mp->sem = xSemaphoreCreateCounting (block_count, block_count);
+      #else
+        mp->sem = NULL;
+      #endif
+
+      if (mp->sem != NULL) {
+        /* Setup memory array */
+        if (mem_mp == 0) {
+          mp->mem_arr = pvPortMalloc (sz);
+        } else {
+          mp->mem_arr = attr->mp_mem;
+        }
+      }
+    }
+
+    if ((mp != NULL) && (mp->mem_arr != NULL)) {
+      /* Memory pool can be created */
+      mp->head    = NULL;
+      mp->mem_sz  = sz;
+      mp->name    = name;
+      mp->bl_sz   = block_size;
+      mp->bl_cnt  = block_count;
+      mp->n       = 0U;
+
+      /* Set heap allocated memory flags */
+      mp->status = MPOOL_STATUS;
+
+      if (mem_cb == 0) {
+        /* Control block on heap */
+        mp->status |= 1U;
+      }
+      if (mem_mp == 0) {
+        /* Memory array on heap */
+        mp->status |= 2U;
+      }
+    }
+    else {
+      /* Memory pool cannot be created, release allocated resources */
+      if ((mem_cb == 0) && (mp != NULL)) {
+        /* Free control block memory */
+        vPortFree (mp);
+      }
+      mp = NULL;
+    }
+  }
+
+  /* Return memory pool ID */
+  return (mp);
+}
+
+/*
+  Get name of a Memory Pool object.
+*/
+const char *osMemoryPoolGetName (osMemoryPoolId_t mp_id) {
+  MemPool_t *mp = (osMemoryPoolId_t)mp_id;
+  const char *p;
+
+  if (IRQ_Context() != 0U) {
+    p = NULL;
+  }
+  else if (mp_id == NULL) {
+    p = NULL;
+  }
+  else {
+    p = mp->name;
+  }
+
+  /* Return name as null-terminated string */
+  return (p);
+}
+
+/*
+  Allocate a memory block from a Memory Pool.
+*/
+void *osMemoryPoolAlloc (osMemoryPoolId_t mp_id, uint32_t timeout) {
+  MemPool_t *mp;
+  void *block;
+  uint32_t isrm;
+
+  if (mp_id == NULL) {
+    /* Invalid input parameters */
+    block = NULL;
+  }
+  else {
+    block = NULL;
+
+    mp = (MemPool_t *)mp_id;
+
+    if ((mp->status & MPOOL_STATUS) == MPOOL_STATUS) {
+      if (IRQ_Context() != 0U) {
+        if (timeout == 0U) {
+          if (xSemaphoreTakeFromISR (mp->sem, NULL) == pdTRUE) {
+            if ((mp->status & MPOOL_STATUS) == MPOOL_STATUS) {
+              isrm  = taskENTER_CRITICAL_FROM_ISR();
+
+              /* Get a block from the free-list */
+              block = AllocBlock(mp);
+
+              if (block == NULL) {
+                /* List of free blocks is empty, 'create' new block */
+                block = CreateBlock(mp);
+              }
+
+              taskEXIT_CRITICAL_FROM_ISR(isrm);
+            }
+          }
+        }
+      }
+      else {
+        if (xSemaphoreTake (mp->sem, (TickType_t)timeout) == pdTRUE) {
+          if ((mp->status & MPOOL_STATUS) == MPOOL_STATUS) {
+            taskENTER_CRITICAL();
+
+            /* Get a block from the free-list */
+            block = AllocBlock(mp);
+
+            if (block == NULL) {
+              /* List of free blocks is empty, 'create' new block */
+              block = CreateBlock(mp);
+            }
+
+            taskEXIT_CRITICAL();
+          }
+        }
+      }
+    }
+  }
+
+  /* Return memory block address */
+  return (block);
+}
+
+/*
+  Return an allocated memory block back to a Memory Pool.
+*/
+osStatus_t osMemoryPoolFree (osMemoryPoolId_t mp_id, void *block) {
+  MemPool_t *mp;
+  osStatus_t stat;
+  uint32_t isrm;
+  BaseType_t yield;
+
+  if ((mp_id == NULL) || (block == NULL)) {
+    /* Invalid input parameters */
+    stat = osErrorParameter;
+  }
+  else {
+    mp = (MemPool_t *)mp_id;
+
+    if ((mp->status & MPOOL_STATUS) != MPOOL_STATUS) {
+      /* Invalid object status */
+      stat = osErrorResource;
+    }
+    else if ((block < (void *)&mp->mem_arr[0]) || (block > (void*)&mp->mem_arr[mp->mem_sz-1])) {
+      /* Block pointer outside of memory array area */
+      stat = osErrorParameter;
+    }
+    else {
+      stat = osOK;
+
+      if (IRQ_Context() != 0U) {
+        if (uxSemaphoreGetCountFromISR (mp->sem) == mp->bl_cnt) {
+          stat = osErrorResource;
+        }
+        else {
+          isrm = taskENTER_CRITICAL_FROM_ISR();
+
+          /* Add block to the list of free blocks */
+          FreeBlock(mp, block);
+
+          taskEXIT_CRITICAL_FROM_ISR(isrm);
+
+          yield = pdFALSE;
+          xSemaphoreGiveFromISR (mp->sem, &yield);
+          portYIELD_FROM_ISR (yield);
+        }
+      }
+      else {
+        if (uxSemaphoreGetCount (mp->sem) == mp->bl_cnt) {
+          stat = osErrorResource;
+        }
+        else {
+          taskENTER_CRITICAL();
+
+          /* Add block to the list of free blocks */
+          FreeBlock(mp, block);
+
+          taskEXIT_CRITICAL();
+
+          xSemaphoreGive (mp->sem);
+        }
+      }
+    }
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Get maximum number of memory blocks in a Memory Pool.
+*/
+uint32_t osMemoryPoolGetCapacity (osMemoryPoolId_t mp_id) {
+  MemPool_t *mp;
+  uint32_t  n;
+
+  if (mp_id == NULL) {
+    /* Invalid input parameters */
+    n = 0U;
+  }
+  else {
+    mp = (MemPool_t *)mp_id;
+
+    if ((mp->status & MPOOL_STATUS) != MPOOL_STATUS) {
+      /* Invalid object status */
+      n = 0U;
+    }
+    else {
+      n = mp->bl_cnt;
+    }
+  }
+
+  /* Return maximum number of memory blocks */
+  return (n);
+}
+
+/*
+  Get memory block size in a Memory Pool.
+*/
+uint32_t osMemoryPoolGetBlockSize (osMemoryPoolId_t mp_id) {
+  MemPool_t *mp;
+  uint32_t  sz;
+
+  if (mp_id == NULL) {
+    /* Invalid input parameters */
+    sz = 0U;
+  }
+  else {
+    mp = (MemPool_t *)mp_id;
+
+    if ((mp->status & MPOOL_STATUS) != MPOOL_STATUS) {
+      /* Invalid object status */
+      sz = 0U;
+    }
+    else {
+      sz = mp->bl_sz;
+    }
+  }
+
+  /* Return memory block size in bytes */
+  return (sz);
+}
+
+/*
+  Get number of memory blocks used in a Memory Pool.
+*/
+uint32_t osMemoryPoolGetCount (osMemoryPoolId_t mp_id) {
+  MemPool_t *mp;
+  uint32_t  n;
+
+  if (mp_id == NULL) {
+    /* Invalid input parameters */
+    n = 0U;
+  }
+  else {
+    mp = (MemPool_t *)mp_id;
+
+    if ((mp->status & MPOOL_STATUS) != MPOOL_STATUS) {
+      /* Invalid object status */
+      n = 0U;
+    }
+    else {
+      if (IRQ_Context() != 0U) {
+        n = uxSemaphoreGetCountFromISR (mp->sem);
+      } else {
+        n = uxSemaphoreGetCount        (mp->sem);
+      }
+
+      n = mp->bl_cnt - n;
+    }
+  }
+
+  /* Return number of memory blocks used */
+  return (n);
+}
+
+/*
+  Get number of memory blocks available in a Memory Pool.
+*/
+uint32_t osMemoryPoolGetSpace (osMemoryPoolId_t mp_id) {
+  MemPool_t *mp;
+  uint32_t  n;
+
+  if (mp_id == NULL) {
+    /* Invalid input parameters */
+    n = 0U;
+  }
+  else {
+    mp = (MemPool_t *)mp_id;
+
+    if ((mp->status & MPOOL_STATUS) != MPOOL_STATUS) {
+      /* Invalid object status */
+      n = 0U;
+    }
+    else {
+      if (IRQ_Context() != 0U) {
+        n = uxSemaphoreGetCountFromISR (mp->sem);
+      } else {
+        n = uxSemaphoreGetCount        (mp->sem);
+      }
+    }
+  }
+
+  /* Return number of memory blocks available */
+  return (n);
+}
+
+/*
+  Delete a Memory Pool object.
+*/
+osStatus_t osMemoryPoolDelete (osMemoryPoolId_t mp_id) {
+  MemPool_t *mp;
+  osStatus_t stat;
+
+  if (mp_id == NULL) {
+    /* Invalid input parameters */
+    stat = osErrorParameter;
+  }
+  else if (IRQ_Context() != 0U) {
+    stat = osErrorISR;
+  }
+  else {
+    mp = (MemPool_t *)mp_id;
+
+    taskENTER_CRITICAL();
+
+    /* Invalidate control block status */
+    mp->status  = mp->status & 3U;
+
+    /* Wake-up tasks waiting for pool semaphore */
+    while (xSemaphoreGive (mp->sem) == pdTRUE);
+
+    mp->head    = NULL;
+    mp->bl_sz   = 0U;
+    mp->bl_cnt  = 0U;
+
+    if ((mp->status & 2U) != 0U) {
+      /* Memory pool array allocated on heap */
+      vPortFree (mp->mem_arr);
+    }
+    if ((mp->status & 1U) != 0U) {
+      /* Memory pool control block allocated on heap */
+      vPortFree (mp);
+    }
+
+    taskEXIT_CRITICAL();
+
+    stat = osOK;
+  }
+
+  /* Return execution status */
+  return (stat);
+}
+
+/*
+  Create new block given according to the current block index.
+*/
+static void *CreateBlock (MemPool_t *mp) {
+  MemPoolBlock_t *p = NULL;
+
+  if (mp->n < mp->bl_cnt) {
+    /* Unallocated blocks exist, set pointer to new block */
+    p = (void *)(mp->mem_arr + (mp->bl_sz * mp->n));
+
+    /* Increment block index */
+    mp->n += 1U;
+  }
+
+  return (p);
+}
+
+/*
+  Allocate a block by reading the list of free blocks.
+*/
+static void *AllocBlock (MemPool_t *mp) {
+  MemPoolBlock_t *p = NULL;
+
+  if (mp->head != NULL) {
+    /* List of free block exists, get head block */
+    p = mp->head;
+
+    /* Head block is now next on the list */
+    mp->head = p->next;
+  }
+
+  return (p);
+}
+
+/*
+  Free block by putting it to the list of free blocks.
+*/
+static void FreeBlock (MemPool_t *mp, void *block) {
+  MemPoolBlock_t *p = block;
+
+  /* Store current head into block memory space */
+  p->next = mp->head;
+
+  /* Store current block as new head */
+  mp->head = p;
+}
+#endif /* FREERTOS_MPOOL_H_ */
+/*---------------------------------------------------------------------------*/
+
+/* Callback function prototypes */
+extern void vApplicationIdleHook (void);
+extern void vApplicationMallocFailedHook (void);
+extern void vApplicationDaemonTaskStartupHook (void);
+
+/**
+  Dummy implementation of the callback function vApplicationIdleHook().
+*/
+#if (configUSE_IDLE_HOOK == 1)
+__WEAK void vApplicationIdleHook (void){}
+#endif
+
+/**
+  Dummy implementation of the callback function vApplicationTickHook().
+*/
+#if (configUSE_TICK_HOOK == 1)
+ __WEAK void vApplicationTickHook (void){}
+#endif
+
+/**
+  Dummy implementation of the callback function vApplicationMallocFailedHook().
+*/
+#if (configUSE_MALLOC_FAILED_HOOK == 1)
+__WEAK void vApplicationMallocFailedHook (void) {
+  /* Assert when malloc failed hook is enabled but no application defined function exists */
+  configASSERT(0);
+}
+#endif
+
+/**
+  Dummy implementation of the callback function vApplicationDaemonTaskStartupHook().
+*/
+#if (configUSE_DAEMON_TASK_STARTUP_HOOK == 1)
+__WEAK void vApplicationDaemonTaskStartupHook (void){}
+#endif
+
+/**
+  Dummy implementation of the callback function vApplicationStackOverflowHook().
+*/
+#if (configCHECK_FOR_STACK_OVERFLOW > 0)
+__WEAK void vApplicationStackOverflowHook (TaskHandle_t xTask, char *pcTaskName) {
+  (void)xTask;
+  (void)pcTaskName;
+
+  /* Assert when stack overflow is enabled but no application defined function exists */
+  configASSERT(0);
+}
+#endif
+
+/*---------------------------------------------------------------------------*/
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
+/*
+  vApplicationGetIdleTaskMemory gets called when configSUPPORT_STATIC_ALLOCATION
+  equals to 1 and is required for static memory allocation support.
+*/
+__WEAK void vApplicationGetIdleTaskMemory (StaticTask_t **ppxIdleTaskTCBBuffer, StackType_t **ppxIdleTaskStackBuffer, uint32_t *pulIdleTaskStackSize) {
+  /* Idle task control block and stack */
+  static StaticTask_t Idle_TCB;
+  static StackType_t  Idle_Stack[configMINIMAL_STACK_SIZE];
+
+  *ppxIdleTaskTCBBuffer   = &Idle_TCB;
+  *ppxIdleTaskStackBuffer = &Idle_Stack[0];
+  *pulIdleTaskStackSize   = (uint32_t)configMINIMAL_STACK_SIZE;
+}
+
+/*
+  vApplicationGetTimerTaskMemory gets called when configSUPPORT_STATIC_ALLOCATION
+  equals to 1 and is required for static memory allocation support.
+*/
+__WEAK void vApplicationGetTimerTaskMemory (StaticTask_t **ppxTimerTaskTCBBuffer, StackType_t **ppxTimerTaskStackBuffer, uint32_t *pulTimerTaskStackSize) {
+  /* Timer task control block and stack */
+  static StaticTask_t Timer_TCB;
+  static StackType_t  Timer_Stack[configTIMER_TASK_STACK_DEPTH];
+
+  *ppxTimerTaskTCBBuffer   = &Timer_TCB;
+  *ppxTimerTaskStackBuffer = &Timer_Stack[0];
+  *pulTimerTaskStackSize   = (uint32_t)configTIMER_TASK_STACK_DEPTH;
+}
+#endif

--- a/src/app/stm32h745i/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2/freertos_mpool.h
+++ b/src/app/stm32h745i/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2/freertos_mpool.h
@@ -1,0 +1,63 @@
+/* --------------------------------------------------------------------------
+ * Copyright (c) 2013-2020 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *      Name:    freertos_mpool.h
+ *      Purpose: CMSIS RTOS2 wrapper for FreeRTOS
+ *
+ *---------------------------------------------------------------------------*/
+
+#ifndef FREERTOS_MPOOL_H_
+#define FREERTOS_MPOOL_H_
+
+#include <stdint.h>
+#include "FreeRTOS.h"
+#include "semphr.h"
+
+/* Memory Pool implementation definitions */
+#define MPOOL_STATUS              0x5EED0000U
+
+/* Memory Block header */
+typedef struct {
+  void *next;                   /* Pointer to next block  */
+} MemPoolBlock_t;
+
+/* Memory Pool control block */
+typedef struct MemPoolDef_t {
+  MemPoolBlock_t    *head;      /* Pointer to head block   */
+  SemaphoreHandle_t  sem;       /* Pool semaphore handle   */
+  uint8_t           *mem_arr;   /* Pool memory array       */
+  uint32_t           mem_sz;    /* Pool memory array size  */
+  const char        *name;      /* Pointer to name string  */
+  uint32_t           bl_sz;     /* Size of a single block  */
+  uint32_t           bl_cnt;    /* Number of blocks        */
+  uint32_t           n;         /* Block allocation index  */
+  volatile uint32_t  status;    /* Object status flags     */
+#if (configSUPPORT_STATIC_ALLOCATION == 1)
+  StaticSemaphore_t  mem_sem;   /* Semaphore object memory */
+#endif
+} MemPool_t;
+
+/* No need to hide static object type, just align to coding style */
+#define StaticMemPool_t         MemPool_t
+
+/* Define memory pool control block size */
+#define MEMPOOL_CB_SIZE         (sizeof(StaticMemPool_t))
+
+/* Define size of the byte array required to create count of blocks of given size */
+#define MEMPOOL_ARR_SIZE(bl_count, bl_size) (((((bl_size) + (4 - 1)) / 4) * 4)*(bl_count))
+
+#endif /* FREERTOS_MPOOL_H_ */

--- a/src/app/stm32h745i/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2/freertos_os2.h
+++ b/src/app/stm32h745i/Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS_V2/freertos_os2.h
@@ -1,0 +1,310 @@
+/* --------------------------------------------------------------------------
+ * Copyright (c) 2013-2021 Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *      Name:    freertos_os2.h
+ *      Purpose: CMSIS RTOS2 wrapper for FreeRTOS
+ *
+ *---------------------------------------------------------------------------*/
+
+#ifndef FREERTOS_OS2_H_
+#define FREERTOS_OS2_H_
+
+#include <string.h>
+#include <stdint.h>
+
+#include "FreeRTOS.h"                   // ARM.FreeRTOS::RTOS:Core
+
+#include CMSIS_device_header
+
+    /*
+  CMSIS-RTOS2 FreeRTOS image size optimization definitions.
+
+  Note: Definitions configUSE_OS2 can be used to optimize FreeRTOS image size when
+        certain functionality is not required when using CMSIS-RTOS2 API.
+        In general optimization decisions are left to the tool chain but in cases
+        when coding style prevents it to optimize the code following optional
+        definitions can be used.
+*/
+
+/*
+  Option to exclude CMSIS-RTOS2 functions osThreadSuspend and osThreadResume from
+  the application image.
+*/
+#ifndef configUSE_OS2_THREAD_SUSPEND_RESUME
+#define configUSE_OS2_THREAD_SUSPEND_RESUME   1
+#endif
+
+/*
+  Option to exclude CMSIS-RTOS2 function osThreadEnumerate from the application image.
+*/
+#ifndef configUSE_OS2_THREAD_ENUMERATE
+#define configUSE_OS2_THREAD_ENUMERATE        1
+#endif
+
+/*
+  Option to disable CMSIS-RTOS2 function osEventFlagsSet and osEventFlagsClear
+  operation from ISR.
+*/
+#ifndef configUSE_OS2_EVENTFLAGS_FROM_ISR
+#define configUSE_OS2_EVENTFLAGS_FROM_ISR     1
+#endif
+
+/*
+  Option to exclude CMSIS-RTOS2 Thread Flags API functions from the application image.
+*/
+#ifndef configUSE_OS2_THREAD_FLAGS
+#define configUSE_OS2_THREAD_FLAGS            configUSE_TASK_NOTIFICATIONS
+#endif
+
+/*
+  Option to exclude CMSIS-RTOS2 Timer API functions from the application image.
+*/
+#ifndef configUSE_OS2_TIMER
+#define configUSE_OS2_TIMER                   configUSE_TIMERS
+#endif
+
+/*
+  Option to exclude CMSIS-RTOS2 Mutex API functions from the application image.
+*/
+#ifndef configUSE_OS2_MUTEX
+#define configUSE_OS2_MUTEX                   configUSE_MUTEXES
+#endif
+
+
+/*
+  CMSIS-RTOS2 FreeRTOS configuration check (FreeRTOSConfig.h).
+
+  Note: CMSIS-RTOS API requires functions included by using following definitions.
+        In case if certain API function is not used compiler will optimize it away.
+*/
+#if (INCLUDE_xSemaphoreGetMutexHolder == 0)
+  /*
+    CMSIS-RTOS2 function osMutexGetOwner uses FreeRTOS function xSemaphoreGetMutexHolder. In case if
+    osMutexGetOwner is not used in the application image, compiler will optimize it away.
+    Set #define INCLUDE_xSemaphoreGetMutexHolder 1 to fix this error.
+  */
+  #error "Definition INCLUDE_xSemaphoreGetMutexHolder must equal 1 to implement Mutex Management API."
+#endif
+#if (INCLUDE_vTaskDelay == 0)
+  /*
+    CMSIS-RTOS2 function osDelay uses FreeRTOS function vTaskDelay. In case if
+    osDelay is not used in the application image, compiler will optimize it away.
+    Set #define INCLUDE_vTaskDelay 1 to fix this error.
+  */
+  #error "Definition INCLUDE_vTaskDelay must equal 1 to implement Generic Wait Functions API."
+#endif
+#if (INCLUDE_xTaskDelayUntil == 0)
+  /*
+    CMSIS-RTOS2 function osDelayUntil uses FreeRTOS function xTaskDelayUntil. In case if
+    osDelayUntil is not used in the application image, compiler will optimize it away.
+    Set #define INCLUDE_xTaskDelayUntil 1 to fix this error.
+  */
+  #error "Definition INCLUDE_xTaskDelayUntil must equal 1 to implement Generic Wait Functions API."
+#endif
+#if (INCLUDE_vTaskDelete == 0)
+  /*
+    CMSIS-RTOS2 function osThreadTerminate and osThreadExit uses FreeRTOS function
+    vTaskDelete. In case if they are not used in the application image, compiler
+    will optimize them away.
+    Set #define INCLUDE_vTaskDelete 1 to fix this error.
+  */
+  #error "Definition INCLUDE_vTaskDelete must equal 1 to implement Thread Management API."
+#endif
+#if (INCLUDE_xTaskGetCurrentTaskHandle == 0)
+  /*
+    CMSIS-RTOS2 API uses FreeRTOS function xTaskGetCurrentTaskHandle to implement
+    functions osThreadGetId, osThreadFlagsClear and osThreadFlagsGet. In case if these
+    functions are not used in the application image, compiler will optimize them away.
+    Set #define INCLUDE_xTaskGetCurrentTaskHandle 1 to fix this error.
+  */
+  #error "Definition INCLUDE_xTaskGetCurrentTaskHandle must equal 1 to implement Thread Management API."
+#endif
+#if (INCLUDE_xTaskGetSchedulerState == 0)
+  /*
+    CMSIS-RTOS2 API uses FreeRTOS function xTaskGetSchedulerState to implement Kernel
+    tick handling and therefore it is vital that xTaskGetSchedulerState is included into
+    the application image.
+    Set #define INCLUDE_xTaskGetSchedulerState 1 to fix this error.
+  */
+  #error "Definition INCLUDE_xTaskGetSchedulerState must equal 1 to implement Kernel Information and Control API."
+#endif
+#if (INCLUDE_uxTaskGetStackHighWaterMark == 0)
+  /*
+    CMSIS-RTOS2 function osThreadGetStackSpace uses FreeRTOS function uxTaskGetStackHighWaterMark.
+    In case if osThreadGetStackSpace is not used in the application image, compiler will
+    optimize it away.
+    Set #define INCLUDE_uxTaskGetStackHighWaterMark 1 to fix this error.
+  */
+  #error "Definition INCLUDE_uxTaskGetStackHighWaterMark must equal 1 to implement Thread Management API."
+#endif
+#if (INCLUDE_uxTaskPriorityGet == 0)
+  /*
+    CMSIS-RTOS2 function osThreadGetPriority uses FreeRTOS function uxTaskPriorityGet. In case if
+    osThreadGetPriority is not used in the application image, compiler will optimize it away.
+    Set #define INCLUDE_uxTaskPriorityGet 1 to fix this error.
+  */
+  #error "Definition INCLUDE_uxTaskPriorityGet must equal 1 to implement Thread Management API."
+#endif
+#if (INCLUDE_vTaskPrioritySet == 0)
+  /*
+    CMSIS-RTOS2 function osThreadSetPriority uses FreeRTOS function vTaskPrioritySet. In case if
+    osThreadSetPriority is not used in the application image, compiler will optimize it away.
+    Set #define INCLUDE_vTaskPrioritySet 1 to fix this error.
+  */
+  #error "Definition INCLUDE_vTaskPrioritySet must equal 1 to implement Thread Management API."
+#endif
+#if (INCLUDE_eTaskGetState == 0)
+  /*
+    CMSIS-RTOS2 API uses FreeRTOS function vTaskDelayUntil to implement functions osThreadGetState
+    and osThreadTerminate. In case if these functions are not used in the application image,
+    compiler will optimize them away.
+    Set #define INCLUDE_eTaskGetState 1 to fix this error.
+  */
+  #error "Definition INCLUDE_eTaskGetState must equal 1 to implement Thread Management API."
+#endif
+#if (INCLUDE_vTaskSuspend == 0)
+  /*
+    CMSIS-RTOS2 API uses FreeRTOS functions vTaskSuspend and vTaskResume to implement
+    functions osThreadSuspend and osThreadResume. In case if these functions are not
+    used in the application image, compiler will optimize them away.
+    Set #define INCLUDE_vTaskSuspend 1 to fix this error.
+
+    Alternatively, if the application does not use osThreadSuspend and
+    osThreadResume they can be excluded from the image code by setting:
+    #define configUSE_OS2_THREAD_SUSPEND_RESUME 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_THREAD_SUSPEND_RESUME == 1)
+    #error "Definition INCLUDE_vTaskSuspend must equal 1 to implement Kernel Information and Control API."
+  #endif
+#endif
+#if (INCLUDE_xTimerPendFunctionCall == 0)
+  /*
+    CMSIS-RTOS2 function osEventFlagsSet and osEventFlagsClear, when called from
+    the ISR, call FreeRTOS functions xEventGroupSetBitsFromISR and
+    xEventGroupClearBitsFromISR which are only enabled if timers are operational and
+    xTimerPendFunctionCall in enabled.
+    Set #define INCLUDE_xTimerPendFunctionCall 1 and #define configUSE_TIMERS 1
+    to fix this error.
+
+    Alternatively, if the application does not use osEventFlagsSet and osEventFlagsClear
+    from the ISR their operation from ISR can be restricted by setting:
+    #define configUSE_OS2_EVENTFLAGS_FROM_ISR 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_EVENTFLAGS_FROM_ISR == 1)
+    #error "Definition INCLUDE_xTimerPendFunctionCall must equal 1 to implement Event Flags API."
+  #endif
+#endif
+
+#if (configUSE_TIMERS == 0)
+  /*
+    CMSIS-RTOS2 Timer Management API functions use FreeRTOS timer functions to implement
+    timer management. In case if these functions are not used in the application image,
+    compiler will optimize them away.
+    Set #define configUSE_TIMERS 1 to fix this error.
+
+    Alternatively, if the application does not use timer functions they can be
+    excluded from the image code by setting:
+    #define configUSE_OS2_TIMER 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_TIMER == 1)
+    #error "Definition configUSE_TIMERS must equal 1 to implement Timer Management API."
+  #endif
+#endif
+
+#if (configUSE_MUTEXES == 0)
+  /*
+    CMSIS-RTOS2 Mutex Management API functions use FreeRTOS mutex functions to implement
+    mutex management. In case if these functions are not used in the application image,
+    compiler will optimize them away.
+    Set #define configUSE_MUTEXES 1 to fix this error.
+
+    Alternatively, if the application does not use mutex functions they can be
+    excluded from the image code by setting:
+    #define configUSE_OS2_MUTEX 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_MUTEX == 1)
+    #error "Definition configUSE_MUTEXES must equal 1 to implement Mutex Management API."
+  #endif
+#endif
+
+#if (configUSE_COUNTING_SEMAPHORES == 0)
+  /*
+    CMSIS-RTOS2 Memory Pool functions use FreeRTOS function xSemaphoreCreateCounting
+    to implement memory pools. In case if these functions are not used in the application image,
+    compiler will optimize them away.
+    Set #define configUSE_COUNTING_SEMAPHORES 1 to fix this error.
+  */
+  #error "Definition configUSE_COUNTING_SEMAPHORES must equal 1 to implement Memory Pool API."
+#endif
+#if (configUSE_TASK_NOTIFICATIONS == 0)
+  /*
+    CMSIS-RTOS2 Thread Flags API functions use FreeRTOS Task Notification functions to implement
+    thread flag management. In case if these functions are not used in the application image,
+    compiler will optimize them away.
+    Set #define configUSE_TASK_NOTIFICATIONS 1 to fix this error.
+
+    Alternatively, if the application does not use thread flags functions they can be
+    excluded from the image code by setting:
+    #define configUSE_OS2_THREAD_FLAGS 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_THREAD_FLAGS == 1)
+    #error "Definition configUSE_TASK_NOTIFICATIONS must equal 1 to implement Thread Flags API."
+  #endif
+#endif
+
+#if (configUSE_TRACE_FACILITY == 0)
+  /*
+    CMSIS-RTOS2 function osThreadEnumerate requires FreeRTOS function uxTaskGetSystemState
+    which is only enabled if configUSE_TRACE_FACILITY == 1.
+    Set #define configUSE_TRACE_FACILITY 1 to fix this error.
+
+    Alternatively, if the application does not use osThreadEnumerate it can be
+    excluded from the image code by setting:
+    #define configUSE_OS2_THREAD_ENUMERATE 0 (in FreeRTOSConfig.h)
+  */
+  #if (configUSE_OS2_THREAD_ENUMERATE == 1)
+    #error "Definition configUSE_TRACE_FACILITY must equal 1 to implement osThreadEnumerate."
+  #endif
+#endif
+
+#if (configUSE_16_BIT_TICKS == 1)
+  /*
+    CMSIS-RTOS2 wrapper for FreeRTOS relies on 32-bit tick timer which is also optimal on
+    a 32-bit CPU architectures.
+    Set #define configUSE_16_BIT_TICKS 0 to fix this error.
+  */
+  #error "Definition configUSE_16_BIT_TICKS must be zero to implement CMSIS-RTOS2 API."
+#endif
+
+#if (configMAX_PRIORITIES != 56)
+  /*
+    CMSIS-RTOS2 defines 56 different priorities (see osPriority_t) and portable CMSIS-RTOS2
+    implementation should implement the same number of priorities.
+    Set #define configMAX_PRIORITIES 56 to fix this error.
+  */
+  #error "Definition configMAX_PRIORITIES must equal 56 to implement Thread Management API."
+#endif
+#if (configUSE_PORT_OPTIMISED_TASK_SELECTION != 0)
+  /*
+    CMSIS-RTOS2 requires handling of 56 different priorities (see osPriority_t) while FreeRTOS port
+    optimised selection for Cortex core only handles 32 different priorities.
+    Set #define configUSE_PORT_OPTIMISED_TASK_SELECTION 0 to fix this error.
+  */
+  #error "Definition configUSE_PORT_OPTIMISED_TASK_SELECTION must be zero to implement Thread Management API."
+#endif
+
+#endif /* FREERTOS_OS2_H_ */


### PR DESCRIPTION
Got FreeRTOS running on both cores.
On the CM7, a task initialises and runs LVGL.
On the CM4 there is a simple task blinking an LED.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable FreeRTOS on both STM32H745I cores to run UI and background work concurrently. CM7 hosts LVGL in a task, and CM4 runs a simple LED blink task.

- **New Features**
  - Added `FreeRTOS-Kernel` and CMSIS-RTOS2 integration.
  - Configured CMake for CM4F and CM7 ports with `heap_4` and `-DUSE_FREERTOS`.
  - Added per-core `FreeRTOSConfig.h`; wired SysTick/SVC/PendSV to the kernel.
  - Created `prvLvglTask` on CM7 (LVGL) and `prvBlinkTask` on CM4 (LED).
  - Set LVGL to `LV_OS_FREERTOS`; refined LCD init logs.

- **Dependencies**
  - New submodule `src/app/middleware/FreeRTOS-Kernel` (run `git submodule update --init`).

<sup>Written for commit 39249d0cc3b1985f4146e14c0d64b0e6932895ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

