### PR TITLE
Fixed monostate check that was not exercised on RPi

### DIFF
--- a/.idea/QtSettings.xml
+++ b/.idea/QtSettings.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="QtSettings">
+    <option name="myCurrentProfile" value="linux-debug" />
+    <option name="mySettingsPerProfile">
+      <map>
+        <entry key="linux-debug">
+          <value>
+            <PerProfileState>
+              <option name="myQmlPath" value="/usr/lib/x86_64-linux-gnu/qt6/qml" />
+              <option name="myQtBinPath" value="/usr/lib/qt6/bin" />
+            </PerProfileState>
+          </value>
+        </entry>
+        <entry key="linux-release">
+          <value>
+            <PerProfileState>
+              <option name="myQmlPath" value="/usr/lib/x86_64-linux-gnu/qt6/qml" />
+              <option name="myQtBinPath" value="/usr/lib/qt6/bin" />
+            </PerProfileState>
+          </value>
+        </entry>
+        <entry key="rpi-debug">
+          <value>
+            <PerProfileState>
+              <option name="myQmlPath" value="/usr/lib/x86_64-linux-gnu/qt6/qml" />
+              <option name="myQtBinPath" value="/usr/lib/qt6/bin" />
+            </PerProfileState>
+          </value>
+        </entry>
+        <entry key="rpi-release">
+          <value>
+            <PerProfileState>
+              <option name="myQmlPath" value="/usr/lib/x86_64-linux-gnu/qt6/qml" />
+              <option name="myQtBinPath" value="/usr/lib/qt6/bin" />
+            </PerProfileState>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/editor.xml
+++ b/.idea/editor.xml
@@ -246,6 +246,8 @@
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=IfStdIsConstantEvaluatedCanBeReplaced/@EntryIndexedValue" value="SUGGESTION" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=StdIsConstantEvaluatedWillAlwaysEvaluateToConstant/@EntryIndexedValue" value="WARNING" type="string" />
     <option name="/Default/CodeInspection/Highlighting/InspectionSeverities/=StringLiteralTypo/@EntryIndexedValue" value="DO_NOT_SHOW" type="string" />
+    <option name="/Default/CodeStyle/CodeFormatting/CppFormatting/ALLOW_COMMENT_AFTER_LBRACE/@EntryValue" value="true" type="bool" />
+    <option name="/Default/CodeStyle/CodeFormatting/CppFormatting/ALLOW_FAR_ALIGNMENT/@EntryValue" value="true" type="bool" />
     <option name="/Default/CodeStyle/CodeFormatting/CppFormatting/INDENT_SIZE/@EntryValue" value="2" type="long" />
     <option name="/Default/CodeStyle/CodeFormatting/CppFormatting/OTHER_BRACES/@EntryValue" value="END_OF_LINE" type="string" />
     <option name="/Default/CodeStyle/CodeFormatting/CppFormatting/TAB_WIDTH/@EntryValue" value="2" type="long" />

--- a/src/io/control/RadioControl.cpp
+++ b/src/io/control/RadioControl.cpp
@@ -38,9 +38,8 @@ RadioControl::configure(const Config::Control::Fields& config)
     if (rc == ResultCode::OK) {
       rc = visit([this](auto&& s) -> ResultCode {
         using T = decay_t<decltype(s)>;
-        if (!is_same_v<T, monostate>) {
+        if constexpr (!is_same_v<T, monostate>) {
           s.connect(&m_internalSink);
-          m_controlSources.emplace_back(move(s));
           return ResultCode::OK;
         } else
         {
@@ -48,6 +47,7 @@ RadioControl::configure(const Config::Control::Fields& config)
         }
       }, source);
       if (rc != ResultCode::OK) {
+        m_controlSources.emplace_back(move(source));
         break;
       }
     } else {


### PR DESCRIPTION
Fixed a problem that showed up on linux-pc due to missing GPIO

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the monostate check in `RadioControl` so Linux PC builds (without GPIO) don’t try to call `connect` on `monostate`. The visitor now uses `if constexpr`, correctly reporting no control sources; behavior on RPi is unchanged.

<sup>Written for commit fc9d0b78c85b28d9270bfe4b0279c48d525c5da4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

