### PR TITLE
Added settings code to STM32 project.

### DIFF
--- a/cmake/platforms/stm32h745i/CM7/CMakeLists.txt
+++ b/cmake/platforms/stm32h745i/CM7/CMakeLists.txt
@@ -74,6 +74,7 @@ set(CM7_SOURCES
     ${SOURCE_DIR_CM7}/lv_conf.h
     ${TINYUSB_SOURCES}
     ${CONFIG_SOURCES}
+    ${SETTINGS_SOURCES}
 )
 
 if(USE_FREERTOS)

--- a/include/CrossPlatformTypes.h
+++ b/include/CrossPlatformTypes.h
@@ -27,6 +27,7 @@ using etl::any_of;
 using etl::ref;
 using etl::make_pair;
 using etl::function;
+// using etl::size_t
 
 #else
 #include <variant>
@@ -55,4 +56,5 @@ using std::any_of;
 using std::ref;
 using std::make_pair;
 using std::function;
+// using std::size_t;
 #endif

--- a/src/app/stm32h745i/CM7/App/Src/main.cpp
+++ b/src/app/stm32h745i/CM7/App/Src/main.cpp
@@ -39,7 +39,6 @@
 #include <device/usbd.h>
 #include <ArduinoJson.h>
 
-
 #ifdef USE_FREERTOS
 #ifdef __cplusplus
  extern "C" {
@@ -54,6 +53,7 @@
 #endif // USE_FREERTOS
 
 #include "config/RadioConfig.h"
+#include "settings/RadioSettings.h"
 
 /* USER CODE END Includes */
 
@@ -126,6 +126,8 @@
 /* USER CODE END 0 */
 
 Config::Radio::Fields radioConfig;
+
+RadioSettings radioSettings;
 
 char MMCPath[4]; /* SD card logical drive path */
 

--- a/src/core/config-settings/settings/Mode.h
+++ b/src/core/config-settings/settings/Mode.h
@@ -1,10 +1,5 @@
-//
-// Created by murray on 5/10/25.
-//
-
 #pragma once
 #include "SettingsCrossPlatformTypes.h"
-
 
 #include <utility>
 

--- a/src/core/config-settings/settings/RadioSettings.cpp
+++ b/src/core/config-settings/settings/RadioSettings.cpp
@@ -4,10 +4,10 @@
 
 #include "RadioSettings.h"
 
-#include "core/util/StringUtils.h"
-
 #ifdef USE_ETL
 #include "etl/string_utilities.h"
+#else
+#include "core/util/StringUtils.h"
 #endif
 
 

--- a/src/core/config-settings/settings/RfSettings.h
+++ b/src/core/config-settings/settings/RfSettings.h
@@ -9,7 +9,6 @@
 
 #include "bands/Bands.h"
 #include "base/SettingsBase.h"
-#include <QDebug>
 #include "base/SteppableSetting.h"
 
 class RfSettings : public SettingsBase

--- a/src/core/config-settings/settings/bands/BandSettings.h
+++ b/src/core/config-settings/settings/bands/BandSettings.h
@@ -3,12 +3,9 @@
 //
 
 #pragma once
-
-#include "Band.h"
-#include "../pipeline/TxPipelineSettings.h"
 #include "../pipeline/RxPipelineSettings.h"
-#include "../base/SettingsBase.h"
-#include <QDebug>
+#include "../pipeline/TxPipelineSettings.h"
+#include "../pipeline/PipelineId.h"
 
 #define MAX_PIPELINES 2
 

--- a/src/core/config-settings/settings/bands/Bands.cpp
+++ b/src/core/config-settings/settings/bands/Bands.cpp
@@ -1,6 +1,3 @@
-//
-// Created by murray on 30/12/25.
-//
 #include "Bands.h"
 
 static BandCategoriesVector bandCategories = {
@@ -67,7 +64,7 @@ static BandCategoriesVector bandCategories = {
   }
 };
 
-Bands::Bands() :
-  m_categories(bandCategories)
+Bands::Bands()
+  : m_categories(bandCategories)
 {
 }

--- a/src/core/config-settings/settings/base/SettingUpdate.h
+++ b/src/core/config-settings/settings/base/SettingUpdate.h
@@ -1,16 +1,15 @@
 #pragma once
 
-#include "SettingUpdatePath.h"
 #include "SettingValue.h"
-#include <variant>
-#include "../Mode.h"
+
+#include "SettingUpdatePath.h"
 
 class SettingUpdate
 {
 public:
   enum Meaning { NONE = 0, VALUE, DELTA };
 
-  SettingUpdate() : m_value(0), m_meaning(NONE), m_cursor(0), m_alt(false) {}
+  SettingUpdate() : m_value(static_cast<uint32_t>(0)), m_meaning(NONE), m_cursor(0), m_alt(false) {}
   SettingUpdate(const SettingUpdatePath& settingPath, SettingValue value, const Meaning meaning, bool alt = false) :
     m_settingPath(settingPath),
     m_value(move(value)),
@@ -59,7 +58,7 @@ public:
   [[nodiscard]] bool isAlt() const { return m_alt; }
 
 
-  SettingUpdate& setValue(SettingValue value) { m_value = std::move(value); return *this; }
+  SettingUpdate& setValue(SettingValue value) { m_value = move(value); return *this; }
   [[nodiscard]] const SettingUpdatePath& getPath() const { return m_settingPath; }
   SettingUpdate& setPath(const SettingUpdatePath& path) { m_settingPath = path; return *this; }
   [[nodiscard]] const SettingValue& getValue() const { return m_value; }

--- a/src/core/config-settings/settings/base/SettingUpdateHelpers.cpp
+++ b/src/core/config-settings/settings/base/SettingUpdateHelpers.cpp
@@ -1,6 +1,6 @@
 #include "SettingUpdateHelpers.h"
 
-#include "core/config-settings/settings/RadioSettings.h"
+#include "../RadioSettings.h"
 
 uint32_t SettingUpdateHelpers::toWithBandFeature(SplitBandId whichBand)
 {

--- a/src/core/config-settings/settings/base/SettingUpdateSink.h
+++ b/src/core/config-settings/settings/base/SettingUpdateSink.h
@@ -12,11 +12,11 @@ public:
   virtual ~SettingUpdateSink() = default;
   virtual ResultCode applySettingUpdate(SettingUpdate& settingDelta) = 0;
 
-  virtual ResultCode applySettingUpdates(SettingUpdate* updates, std::size_t count)
+  virtual ResultCode applySettingUpdates(SettingUpdate* updates, size_t count)
   {
     ResultCode rc = ResultCode::OK;
     if (!updates) return rc;
-    for (std::size_t i = 0; i < count; ++i) {
+    for (size_t i = 0; i < count; ++i) {
       updates[i].resetCursor();
       rc = applySettingUpdate(updates[i]);
       if (rc != ResultCode::OK) {
@@ -27,8 +27,8 @@ public:
   }
 
   // Convenience for std::array + prefix length (optional)
-  template <std::size_t N>
-  ResultCode applySettingUpdates(std::array<SettingUpdate, N>& updates, std::size_t count)
+  template <size_t N>
+  ResultCode applySettingUpdates(std::array<SettingUpdate, N>& updates, size_t count)
   {
     if (count > N) count = N;
     return applySettingUpdates(updates.data(), count);

--- a/src/core/config-settings/settings/base/SettingValue.h
+++ b/src/core/config-settings/settings/base/SettingValue.h
@@ -1,12 +1,11 @@
 #pragma once
 
 #include <cstdint>
-#include "CrossPlatformTypes.h"
+#include <CrossPlatformTypes.h>
 #include "../Mode.h"
-#include "core/config-settings/settings/bands/SplitBandId.h"
-#include "core/config-settings/settings/pipeline/PipelineId.h"
-#include "core/config-settings/settings/AgcSpeed.h"
-#include "core/config-settings/settings/SettingsCrossPlatformTypes.h"
+#include "../AgcSpeed.h"
+#include "../bands/SplitBandId.h"
+#include "../pipeline/PipelineId.h"
 
 /**
  * The unified variant type for all setting data in the system.

--- a/src/core/config-settings/settings/base/SettingsBase.h
+++ b/src/core/config-settings/settings/base/SettingsBase.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "../SettingsCrossPlatformTypes.h"
-#include "SettingValue.h"
+// #include "SettingValue.h"
 #include "SettingUpdate.h"
 #include "SettingRegistry.h"
 #include "Setting.h"

--- a/src/core/config-settings/settings/pipeline/RxPipelineSettings.h
+++ b/src/core/config-settings/settings/pipeline/RxPipelineSettings.h
@@ -5,7 +5,6 @@
 #pragma once
 #include "../IfSettings.h"
 #include "PipelineSettings.h"
-#include <QDebug>
 
 class RxPipelineSettings : public PipelineSettings
 {


### PR DESCRIPTION
Settings code added to STM32 project.
Removed fixed references to std::

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates the shared settings system into the STM32H745 CM7 target and builds it with ETL collections. Removes Qt and `std::`-locked dependencies so the settings code compiles cleanly on embedded.

- **New Features**
  - Add `${SETTINGS_SOURCES}` to the CM7 CMake and wire `RadioSettings` into `main.cpp` (include and instance).

- **Refactors**
  - Gate string utilities on `USE_ETL`; switch to cross‑platform includes and use `size_t` instead of `std::size_t`.
  - Remove Qt headers and other host-only includes from settings/band/pipeline headers; simplify include paths.
  - Minor cleanups: safer default init in `SettingUpdate`, consistent constructors and formatting.

<sup>Written for commit cd386726011cf0ac27675b15b589728e5e06248b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

